### PR TITLE
Microsoft Edge download naming

### DIFF
--- a/src/components/predictive-model-page/mapbox/PredictiveMap.js
+++ b/src/components/predictive-model-page/mapbox/PredictiveMap.js
@@ -203,7 +203,7 @@ class PredictiveMap extends Component {
     // Creates and returns a string to name the downloaded PDF
     // in the format 'StateYear.pdf"
     returnMapName() {
-        return(`${this.state.dataControllerState.userFilters.stateName}${this.state.dataControllerState.userFilters.predictiveModelDate}`);
+        return(`${this.state.dataControllerState.userFilters.stateName}${this.state.dataControllerState.userFilters.predictiveModelDate}`+'.pdf');
     }
 
     // Creates and returns an HTML object with information for the footer


### PR DESCRIPTION
Chrome was downloading a file eg: "Florida1992", and downloading/opening it as a pdf. Edge would take "Florida1992" and download it as an extensionless file. I added the .pdf extension to the filename. Tested on local server and confirms function on Edge while still working on Chrome.