### PR TITLE
Add deploy script to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "clean": "rm -rf build",
+    "deploy": "yarn build; surge -p build -d https://pine-beetle-prediction.surge.sh; yarn clean"
   },
   "eslintConfig": {
     "extends": "react-app"


### PR DESCRIPTION
# Add deploy script to package

Can now publish to frontend (if signed in with surge) using `yarn deploy`.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Resolved any merge conflicts
- [x] Updated documentation
- [x] Added and passed unit/integration tests