### PR TITLE
Display info for missing geo data 

### DIFF
--- a/src/components/predictive-model-page/ModelBreakDown.js
+++ b/src/components/predictive-model-page/ModelBreakDown.js
@@ -41,23 +41,42 @@ class ModelBreakDown extends Component {
                         }
                     }
                 }
-
-                return(
-                    <div className="container flex-item-right" id="model-breakdown-container">
-                        <table id="model-breakdown-table">
-                            <thead>
-                                <tr>
-                                    <th>Forest Name</th>
-                                    <th>% Probability of Any Spots</th>
-                                    <th>% Probability of >53 Spots</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {outputs}
-                            </tbody>
-                        </table>
-                    </div>
-                );
+                if (outputs.length ===0){
+                    return(
+                        <div className="container flex-item-right" id="model-breakdown-container">
+                            <table id="model-breakdown-table">
+                                <thead>
+                                    <tr>
+                                        <th>Forest Name</th>
+                                        <th>% Probability of Any Spots</th>
+                                        <th>% Probability of >53 Spots</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                </tbody>
+                            </table>
+                            <p id="model-breakdown-no-data"> No data</p>
+                        </div>
+                    )
+                }
+                else {
+                    return(
+                        <div className="container flex-item-right" id="model-breakdown-container">
+                            <table id="model-breakdown-table">
+                                <thead>
+                                    <tr>
+                                        <th>Forest Name</th>
+                                        <th>% Probability of Any Spots</th>
+                                        <th>% Probability of >53 Spots</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {outputs}
+                                </tbody>
+                            </table>
+                        </div>
+                    );
+                }
             }
             else {
                 return(

--- a/src/styles/predictive-model-page/ModelBreakDown.css
+++ b/src/styles/predictive-model-page/ModelBreakDown.css
@@ -18,3 +18,8 @@
     text-align: center;
     padding: 10px;
 }
+#model-breakdown-no-data{
+    background-color: #CCE1B6;
+    font-size: 16px;
+    padding: 10px;
+}


### PR DESCRIPTION
# Title
Display info for missing geo data, (different from predictions missing data) which leaves empty space. See #265 

*** First front-end code changes. If this isn't the exact right way to make these changes, reject PR + slack me pls. 

- Fixes #265 

## Type of Change

- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Documentation update


## Referenced Issue(s)

- #265 

## Screenshots/Screen Recordings

Please attach screenshots or screen recordings if you made a UI change.
![image](https://user-images.githubusercontent.com/48935297/74610704-9eb92500-50c3-11ea-81a9-bbc96b6cfa4f.png)
