### PR TITLE
Fix misspelled state

### DIFF
--- a/src/constants/state-abbreviations.json
+++ b/src/constants/state-abbreviations.json
@@ -12,7 +12,7 @@
     "NJ": "New Jersey",
     "OK": "Oklahoma",
     "SC": "South Carolina",
-    "TN": "Tennesse",
+    "TN": "Tennessee",
     "TX": "Texas",
     "VA": "Virginia"
 }


### PR DESCRIPTION
# Description

Tennessee wasn't spelled correctly

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update