### PR TITLE
Round chartjs tooltip to two decimal places

### DIFF
--- a/src/screens/trapping-data/components/line-chart/index.js
+++ b/src/screens/trapping-data/components/line-chart/index.js
@@ -82,6 +82,17 @@ const LineChart = (props) => {
       bodyFontFamily: 'Inter',
       bodyFontColor: '#ffffff',
       bodyAlign: 'left',
+
+      // set custom label (rounds spb and clerid per 2 weeks)
+      callbacks: {
+        label: (tooltipItem, d) => {
+          const { label } = d.datasets[tooltipItem.datasetIndex];
+          const value = tooltipItem.yLabel;
+
+          if (label === 'Total Spots') return `${label}: ${value}`;
+          else return `${label}: ${value.toFixed(2)}`;
+        },
+      },
     },
     legend: {
       display: true,


### PR DESCRIPTION
# Description

Hover tooltip on trapping data graph now rounds to two decimal places for spb and clerid per two weeks

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update