### PR TITLE
Add tooltip to download for no safari

### DIFF
--- a/src/screens/prediction/components/prediction-map/component.js
+++ b/src/screens/prediction/components/prediction-map/component.js
@@ -1,5 +1,6 @@
 /* eslint-disable prefer-destructuring */
 import React, { useState, useEffect } from 'react';
+import ReactTooltip from 'react-tooltip';
 import mapboxgl from 'mapbox-gl/dist/mapbox-gl';
 import printPdf from 'mapbox-print-pdf';
 
@@ -10,6 +11,11 @@ import {
 } from '../../../../utils';
 
 import './style.scss';
+
+const questionIcon = require('../../../../assets/icons/help-circle.png');
+
+const helpText = `Please use Chrome, Firefox,<br />
+or Edge to download map.`;
 
 const thresholds = ['0-2.5%', '2.5-5%', '5-15%', '15-25%', '25-40%', '40-100%'];
 const colors = ['#86CCFF', '#FFC148', '#FFA370', '#FF525C', '#CB4767', '#6B1B38'];
@@ -308,7 +314,7 @@ const PredictionMap = (props) => {
       const layer = curr;
       const color = colors[index];
       const spanString = `
-          <div class="footer-legend-key" style="font-family: 'Open Sans', arial, serif;background: ${color};display: 
+          <div class="footer-legend-key" style="font-family: 'Open Sans', arial, serif;background: ${color};display:
           inline-block;border-radius: 20%;width: 20px;height: 20px;margin-right: 5px;margin-left: 5px;"></div><span>${layer}</span>`;
       return acc.concat(spanString);
     }, '');
@@ -319,24 +325,24 @@ const PredictionMap = (props) => {
               <div id="footer-legend" style="font-family: 'Open Sans', arial, serif;width: 90%;margin: auto;margin-bottom: 10px;">
                   ${legendString}
               </div>
-              <p class="footnote" style="font-family: 'Open Sans', arial, serif;color: #898989;line-height: 
-              14px;width: 53%;margin: auto;margin-bottom: 16px;font-size: 14px;">Note: Color ramp ascends with a constant factor of 
+              <p class="footnote" style="font-family: 'Open Sans', arial, serif;color: #898989;line-height:
+              14px;width: 53%;margin: auto;margin-bottom: 16px;font-size: 14px;">Note: Color ramp ascends with a constant factor of
               increase in the probability of outcome.</p>
               <div id="spacer" style="height: 50px;"></div>
               <h2 style="font-family: 'Open Sans', arial, serif;margin-bottom: 16px;margin-top: 16px;">${title}</h2>
-              <p style="font-family: 'Open Sans', arial, serif;font-size: 14px;margin-bottom: 16px;">Predictions are based on a zero-inflated Poisson model fit to historical data 
+              <p style="font-family: 'Open Sans', arial, serif;font-size: 14px;margin-bottom: 16px;">Predictions are based on a zero-inflated Poisson model fit to historical data
               from 1988 – 2009 (Aoki 2017). The most important drivers of model predictions are
                SPB trap captures in the current spring and SPB spots the previous year.
               </p>
               <p style="font-family: 'Open Sans', arial, serif;font-size: 14px;margin-bottom: 16px;">
-              The SPB prediction project is supported by USDA Forest Service: Science and Technology 
+              The SPB prediction project is supported by USDA Forest Service: Science and Technology
               Development Program (STDP)
               </p>
               <p style="font-family: 'Open Sans', arial, serif;font-size: 14px;margin-bottom: 16px;">Contact: Matthew P. Ayres - matthew.p.ayres@dartmouth.edu; Carissa F. Aoki - caoki@bates.edu
               </p>
               <p class="footnote" style="font-family: 'Open Sans', arial, serif;color: #898989;line-height: 14px;width: 53%;
-              margin: auto;margin-bottom: 16px;font-size: 14px;">Sources: Esri, HERE, Garmin, Intermap, increment P Corp., GEBCO, USGS,FAO, NPS, NRCAN, 
-              GeoBase, IGN, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), swisstopo, © OpenStreetMap 
+              margin: auto;margin-bottom: 16px;font-size: 14px;">Sources: Esri, HERE, Garmin, Intermap, increment P Corp., GEBCO, USGS,FAO, NPS, NRCAN,
+              GeoBase, IGN, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), swisstopo, © OpenStreetMap
               contributors, andthe GIS User Community</p>
           </div>
           `
@@ -441,6 +447,14 @@ const PredictionMap = (props) => {
       <div id="map" />
       <div id="map-overlay-download" onClick={downloadMap}>
         <h4>{isDownloadingMap ? 'Downloading...' : 'Download Map'}</h4>
+        <div>
+          <img id="icon"
+            data-tip={helpText}
+            src={questionIcon}
+            alt="Help"
+          />
+          <ReactTooltip multiline place="right" />
+        </div>
       </div>
       <div className="map-overlay-legend" id="legend">
         <div className="legend-key-title">Probability of &gt;50 spots</div>

--- a/src/screens/prediction/components/prediction-map/style.scss
+++ b/src/screens/prediction/components/prediction-map/style.scss
@@ -18,6 +18,9 @@
 
 #map-overlay-download {
     position: absolute;
+    display: flex;
+    flex: row;
+    justify-content: center;
     bottom: 0;
     right: 10;
     background: rgba(255, 255, 255, 0.8);
@@ -36,6 +39,13 @@
     cursor: pointer;
 }
 
+#icon {
+    width: 15px;
+    height: 15px;
+    margin-top: 0;
+    margin-left: 4px;
+}
+
 .map-overlay-legend {
     position: absolute;
     bottom: 25px;
@@ -51,15 +61,15 @@
 }
 
 .map-overlay-hover-area {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  background: rgba(255, 255, 255, 0.9);
-  margin-left: 10px;
-  overflow: auto;
-  border-radius: 3px;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    background: rgba(255, 255, 255, 0.9);
+    margin-left: 10px;
+    overflow: auto;
+    border-radius: 3px;
 }
-  
+
 #features {
     top: 0;
     height: 55px;
@@ -71,7 +81,7 @@
     text-align: left;
     font-size: .7em;
 }
-  
+
 #legend {
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
     line-height: 15px;
@@ -86,7 +96,7 @@
     flex-direction: column;
     justify-content: space-between;
 }
-  
+
 .legend-key {
     display: inline-block;
     width: 22px;
@@ -104,9 +114,9 @@
 
 
 #choropleth-map-p-area p {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  padding-bottom: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    padding-bottom: 0px;
 }
 
 .download-button {
@@ -174,7 +184,7 @@
 
 #map-header h2 {
     letter-spacing: 1px;
-    /* if a large enough margin-top is not included, 
+    /* if a large enough margin-top is not included,
     the title in the printed pdf cannot be seen*/
     margin-top: 200px;
     margin-bottom: 50px;


### PR DESCRIPTION
# Description

Added a tooltip to right of download button. "Please use Chrome, Firefox, or Edge to download map."

Also inadvertently stripped some trailing whitespace/fixed a few indents due to my auto-fix on save.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- closes #412 

## Screenshots

<img width="342" alt="image" src="https://user-images.githubusercontent.com/28827171/100136752-7122b880-2e59-11eb-927e-861f05810a68.png">

