### PR TITLE
tooltips for prediction detail

### DIFF
--- a/src/screens/prediction/components/prediction-details/component.js
+++ b/src/screens/prediction/components/prediction-details/component.js
@@ -8,7 +8,8 @@ import { DATA_MODES } from '../../../../constants';
 const trapIcon = require('../../../../assets/icons/trap.png');
 const cleridIcon = require('../../../../assets/icons/clerids.png');
 
-const tooltipText = 'per two weeks, averaged across traps';
+const spbText = 'SPB per two weeks, averaged across traps';
+const cleridText = 'clerids per two weeks, averaged across traps';
 
 const PredictionDetails = (props) => {
   const {
@@ -75,7 +76,7 @@ const PredictionDetails = (props) => {
                         src={cleridIcon}
                         alt="clerids"
                       />
-                      <div className="content-text" data-tip={tooltipText}>{Math.round(data[0].cleridst1)} <u>clerids</u></div>
+                      <div className="content-text" data-tip={cleridText}>{Math.round(data[0].cleridst1)} <u>clerids</u></div>
                       <ReactTooltip multiline place="right" />
                     </div>
                   </div>
@@ -100,7 +101,7 @@ const PredictionDetails = (props) => {
                         src={cleridIcon}
                         alt="spb"
                       />
-                      <div className="content-text" data-tip={tooltipText}>{Math.round(data[0].SPB)} <u>SPB</u></div>
+                      <div className="content-text" data-tip={spbText}>{Math.round(data[0].SPB)} <u>SPB</u></div>
                       <ReactTooltip multiline place="right" />
                     </div>
                   </div>


### PR DESCRIPTION
# Description

added tooltips to clarify /2 weeks across traps for both SPB/clerids. feel free to roast on specific wording.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- closes #429 

## Screenshots

<img width="512" alt="image" src="https://user-images.githubusercontent.com/28827171/100168425-3e93b280-2e8f-11eb-804c-2920b4ddab60.png">
