### PR TITLE
Preserve state/year selections when switching data mode

### DIFF
--- a/src/state/reducers/predictions.js
+++ b/src/state/reducers/predictions.js
@@ -40,7 +40,7 @@ const PredictionsReducer = (state = initialState, action) => {
       return { ...state, fetchingCustomPrediction: action.payload };
 
     case ActionTypes.SET_DATA_MODE:
-      return { ...state, data: action.payload.mode === DATA_MODES.COUNTY ? state.county : state.rangerDistrict };
+      return { ...state, data: filterYear(filterLocation(getFullDataArray(action.payload.mode, state), action), action) };
 
     case ActionTypes.SET_YEAR:
       return {

--- a/src/state/reducers/selections.js
+++ b/src/state/reducers/selections.js
@@ -21,7 +21,7 @@ const SelectionsReducer = (state = initialState, action) => {
       return { ...state, year: action.payload.year };
 
     case ActionTypes.SET_YEAR_RANGE:
-      let { startYear, endYear } = action.payload.yearRange;
+      const { startYear, endYear } = action.payload.yearRange;
 
       return {
         ...state,
@@ -41,19 +41,18 @@ const SelectionsReducer = (state = initialState, action) => {
       return { ...state, rangerDistrict: action.payload.rangerDistrict };
 
     case ActionTypes.SET_DATA_MODE:
-      const { trappingData, mode } = action.payload;
-
-      startYear = trappingData.reduce((prev, curr) => (prev.year < curr.year ? prev : curr), {})?.year || state.yearRange.startYear;
-      endYear = trappingData.reduce((prev, curr) => (prev.year > curr.year ? prev : curr), {})?.year || state.yearRange.endYear;
+      const {
+        mode,
+        state: newState,
+        year: newYear,
+        yearRange: newYearRange,
+      } = action.payload;
 
       return {
         ...state,
-        year: endYear,
-        yearRange: {
-          startYear,
-          endYear,
-        },
-        state: '',
+        year: newYear,
+        yearRange: newYearRange,
+        state: newState,
         county: '',
         rangerDistrict: '',
         dataMode: mode,

--- a/src/state/reducers/trapping.js
+++ b/src/state/reducers/trapping.js
@@ -32,7 +32,7 @@ const TrappingReducer = (state = initialState, action) => {
       return { ...state, fetchingRangerDistrict: action.payload };
 
     case ActionTypes.SET_DATA_MODE:
-      return { ...state, data: action.payload.mode === DATA_MODES.COUNTY ? state.county : state.rangerDistrict };
+      return { ...state, data: filterYearRange(filterLocation(getFullDataArray(action.payload.mode, state), action), action) };
 
     case ActionTypes.SET_YEAR:
       return state;


### PR DESCRIPTION
# Description

When changing data mode we now preserve state and year selections if those selections appear in the new data

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Tickets

- closes #435 