### PR TITLE
Favicon working again

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
   <head>
     <title>Pine Beetle Prediction</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="icon" type="image/png" href="https://raw.githubusercontent.com/dali-lab/pine-beetle-frontend/ebcffb0c051c94e402d5eef41011fe22071c23b9/public/favicon.png?token=AJP6RUKPPOIAEU3R7INZHGS7OVS4Q" />
+    <link rel="icon" type="image/png" href="./black-beetle-logo.png" />
     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700,300i,400i,600i,700i" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,600,700,300i,400i,600i,700i" rel="stylesheet">
     <link rel="preconnect" href="https://fonts.gstatic.com">


### PR DESCRIPTION
# Description

Favicon link was sending 404, now just rendering one of the bundled images

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Tickets

- closes #479 