### PR TITLE
Add blur hovers to trapping map, download buttons, fix indentation

### DIFF
--- a/src/screens/prediction/components/prediction-map/style.scss
+++ b/src/screens/prediction/components/prediction-map/style.scss
@@ -20,7 +20,8 @@
     justify-content: center;
     bottom: 0;
     right: 10;
-    background: rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(2px);
     font-family: 'Inter';
     border-radius: 3px;
     padding: 10px;

--- a/src/screens/trapping-data/components/trapping-data-map/style.scss
+++ b/src/screens/trapping-data/components/trapping-data-map/style.scss
@@ -27,15 +27,15 @@
 }
 
 .map-overlay-hover-area {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  background: rgba(255, 255, 255, 0.9);
-  margin-left: 10px;
-  overflow: auto;
-  border-radius: 3px;
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    background: rgba(255, 255, 255, 0.9);
+    margin-left: 10px;
+    overflow: auto;
+    border-radius: 3px;
 }
-  
+
 #features {
     top: 0;
     height: 55px;
@@ -47,7 +47,7 @@
     text-align: left;
     font-size: .7em;
 }
-  
+
 #legend {
     box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
     line-height: 15px;
@@ -62,7 +62,7 @@
     flex-direction: column;
     justify-content: space-between;
 }
-  
+
 .legend-key {
     display: inline-block;
     width: 22px;
@@ -80,9 +80,9 @@
 
 
 #choropleth-map-p-area p {
-  margin-top: 0px;
-  margin-bottom: 0px;
-  padding-bottom: 0px;
+    margin-top: 0px;
+    margin-bottom: 0px;
+    padding-bottom: 0px;
 }
 
 .download-button {
@@ -149,7 +149,7 @@
 
 #map-header h2 {
     letter-spacing: 1px;
-    /* if a large enough margin-top is not included, 
+    /* if a large enough margin-top is not included,
     the title in the printed pdf cannot be seen*/
     margin-top: 200px;
     margin-bottom: 50px;
@@ -178,6 +178,9 @@
     color: white;
     text-align: left;
     border-radius: 10px;
+    -webkit-backdrop-filter: blur(70px);
+    backdrop-filter: blur(70px);
+    background-color: rgba(17, 18, 22, 0.75);
 
     h3 {
         margin-bottom: 10px;
@@ -188,7 +191,8 @@
     position: absolute;
     bottom: 0;
     right: 10;
-    background: rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.9);
+    backdrop-filter: blur(2px);
     font-family: 'Inter';
     border-radius: 3px;
     padding: 10px;


### PR DESCRIPTION
# Description

Trapping hovers were not blurred properly so I added those. download buttons were updated to blur like the legend.

some whitespaces were fixed in css too.

![image](https://user-images.githubusercontent.com/28827171/100923324-03a40700-34ad-11eb-863f-02cdc4c9c6eb.png)

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update
