### PR TITLE
Add ellipses to input overflow

### DIFF
--- a/src/components/input-components/style.scss
+++ b/src/components/input-components/style.scss
@@ -1,0 +1,5 @@
+select {
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}


### PR DESCRIPTION
# Description

When input bar goes over length, add ellipses

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Screenshots
![image (3)](https://user-images.githubusercontent.com/39839953/100926117-85ddfc80-34a8-11eb-8bb7-6feea0f911dd.png)
