### PR TITLE
upload guide and navbar fix

### DIFF
--- a/src/components/header/component.js
+++ b/src/components/header/component.js
@@ -39,7 +39,7 @@ const Header = (props) => {
             <div id="nav-buttons">
               <div id="button-container">
                 {Object.entries(routes).map(([key, value]) => (
-                  <Link to={key} key={key} className={`nav-button ${(useLocation().pathname === key) ? 'active-nav' : 'inactive-nav'}`}>
+                  <Link to={key} key={key} className={`${value === 'About' ? 'nav-button-short' : 'nav-button'} ${(useLocation().pathname === key) ? 'active-nav' : 'inactive-nav'}`}>
                     {value}
                   </Link>
                 ))}

--- a/src/components/header/style.scss
+++ b/src/components/header/style.scss
@@ -61,6 +61,10 @@
                 .nav-button {
                     width: 135px;
                 }
+
+                .nav-button-short {
+                    width: 95px;
+                }
             }
 
             #data-mode-toggle-container {

--- a/src/screens/admin/component.js
+++ b/src/screens/admin/component.js
@@ -12,6 +12,8 @@ import { runPipeline } from '../../services/admin';
 
 import './style.scss';
 
+const guideURL = 'https://docs.google.com/document/u/1/d/e/2PACX-1vS-VkOBKcB3_nAsyIYUU-ogG-zezQd-XZmDt5SFqMPd6OkrpRXGtoa1_Fr0gDL6LBIwzQI9A6Ix3JKr/pub';
+
 const Admin = (props) => {
   const {
     isLoggedIn,
@@ -48,6 +50,7 @@ const Admin = (props) => {
         <h1>Admin Dashboard</h1>
         <div id="auth-header">
           <p>Hi, {lastName ? `${firstName} ${lastName}` : firstName}!</p>
+          <p>Before uploading any data, please read <a href={guideURL} target="_blank" rel="noopener noreferrer">this guide</a>.</p>
           <div id="header-options">
             <p id="sign-out" onClick={signOut}>Sign Out</p>
             <p id="change-password" onClick={() => setChangePasswordVisible(true)}>Change Password</p>
@@ -55,7 +58,7 @@ const Admin = (props) => {
         </div>
         <div id="dashboard-container">
           <div id="dashboard">
-            <div id="upload-container"><FileUpload /></div>
+            <div id="upload-container"><FileUpload guideURL={guideURL} /></div>
             <div id="user-container">
               <div id="users-container"><Users /></div>
               <div id="add-users"><AddUser /></div>

--- a/src/screens/admin/components/file-upload/component.js
+++ b/src/screens/admin/components/file-upload/component.js
@@ -8,7 +8,9 @@ import {
 
 import './style.scss';
 
-const FileUpload = () => {
+const FileUpload = (props) => {
+  const { guideURL } = props;
+
   const [countySpotFile, setCountySpotFile] = useState();
   const [rdSpotFile, setRdSpotFile] = useState();
   const [unsummarizedFile, setUnsummarizedFile] = useState();
@@ -90,7 +92,7 @@ const FileUpload = () => {
   if (uploadingFileError) {
     return (
       <div id="uploading-error-container" className="uploading-message-container">
-        <h3>{uploadingFileError}</h3>
+        <h3>{uploadingFileError} Please read <a href={guideURL} target="_blank" rel="noopener noreferrer">this guide</a> for uploading data.</h3>
         <button
           type="button"
           onClick={clearError}

--- a/src/screens/admin/style.scss
+++ b/src/screens/admin/style.scss
@@ -21,6 +21,7 @@
         #header-options {
             display: flex;
             margin-top: 10px;
+            justify-content: center;
 
             p {
                 color: #2f303a;


### PR DESCRIPTION
# Description

Added links to the upload guide in admin page, both at the top of the page and bolded in the error state message.

Added a shorter css for the navbar 'About' page since it looked really awkward when it was larger.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets
- closes #451 

## Screenshots

<img width="1399" alt="Screen Shot 2021-01-22 at 12 00 16 AM" src="https://user-images.githubusercontent.com/28827171/105464274-23061780-5c46-11eb-878b-79a3488a934c.png">

