### PR TITLE
add explanatory text

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,8 @@
         "jsx-a11y/no-noninteractive-element-interactions": 0,
         "react/jsx-one-expression-per-line":0,
         "no-useless-escape": 0,
-        "jsx-a11y/no-static-element-interactions": 0
+        "jsx-a11y/no-static-element-interactions": 0,
+        "linebreak-style": ["error", "windows"]
     },
     "plugins": [
         "react"

--- a/.eslintrc
+++ b/.eslintrc
@@ -36,7 +36,6 @@
         "react/jsx-one-expression-per-line":0,
         "no-useless-escape": 0,
         "jsx-a11y/no-static-element-interactions": 0,
-        "linebreak-style": ["error", "windows"]
     },
     "plugins": [
         "react"

--- a/src/screens/trapping-data/components/overview-text/component.js
+++ b/src/screens/trapping-data/components/overview-text/component.js
@@ -10,17 +10,30 @@ You can switch between map or chart<br />
 view by toggling the button below.`;
 
 const OverviewText = _props => (
-  <div className="container" id="overview-text">
-    <h1 id="title">
-      Historical and Model Input Data
-    </h1>
-    <img id="icon"
-      data-tip={helpText}
-      src={questionIcon}
-      alt="Help"
-    />
-    <ReactTooltip multiline place="right" />
+  <div className="container" id="overview-explanation">
+    <div className="container" id="overview-text">
+      <h1 id="title">
+        Historical and Model Input Data
+      </h1>
+      <img id="icon"
+        data-tip={helpText}
+        src={questionIcon}
+        alt="Help"
+      />
+      <ReactTooltip multiline place="right" />
+    </div>
+    <p id="explanatory-text">Southern pine beetle trapping data has been collected across the Southeast since 1988, and now,
+      increasingly, in the Mid-Atlantic and Northeast. All historical data is collected here in one place
+      for researchers, forest resource managers, and the general public to access. [Insert explanation here
+      for all the different ways the data can be downloaded, so users know that ALL forms of the data, both raw
+      (weekly) and summarized (every two weeks; the input version used for the model) are available.]
+    </p>
+    <p id="explanatory-text">
+      Past predictions and observed outcomes can also be visualized and downloaded here. [Insert explanation here
+      (or link to further explanation) for the different ways to view the predicted/observed information.]
+    </p>
   </div>
+
 );
 
 export default OverviewText;

--- a/src/screens/trapping-data/components/overview-text/style.scss
+++ b/src/screens/trapping-data/components/overview-text/style.scss
@@ -5,11 +5,24 @@
     margin-bottom: 50px;
 }
 
+#overview-explanation {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    margin-bottom: 30px;
+}
+
 #title {
     font-family: 'Inter';
     font-size: 44px;
     letter-spacing: 1;
     margin-right: 21px;
+}
+
+#explanatory-text{
+    font-family: 'Inter';
+    font-size: 15px;
+    margin-bottom: 15px;
 }
 
 #icon {


### PR DESCRIPTION
# add explanatory text to historical and model input data page

added the text given by Carissa to the historical and model input data page. note that this is not the final text, just a placeholder of about the same length as the final version

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Tickets

- [522](https://app.zenhub.com/workspaces/pine-beetle-prediction-tool-5d8ab1b0022c8d0001c05ba8/issues/dali-lab/pine-beetle-frontend/522)

## Screenshots
<img width="924" alt="explanatory-text" src="https://user-images.githubusercontent.com/13407296/150693658-410cfd52-5f40-4978-9858-b4c6aedfbe08.PNG">

