### PR TITLE
map view always renders first

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,8 @@
         "jsx-a11y/no-noninteractive-element-interactions": 0,
         "react/jsx-one-expression-per-line":0,
         "no-useless-escape": 0,
-        "jsx-a11y/no-static-element-interactions": 0
+        "jsx-a11y/no-static-element-interactions": 0,
+        //"linebreak-style": ["error", "windows"]
     },
     "plugins": [
         "react"

--- a/src/app.js
+++ b/src/app.js
@@ -40,7 +40,6 @@ import {
 
 import {
   getAuthTokenFromStorage,
-  getChartModeFromStorage,
   getDataModeFromStorage,
   getUserIdFromStorage,
 } from './utils';
@@ -68,7 +67,7 @@ const App = (props) => {
 
     // set data/chart mode if persist in browser
     props.setDataMode(getDataModeFromStorage() || DATA_MODES.COUNTY);
-    props.setChartMode(getChartModeFromStorage() || CHART_MODES.MAP);
+    props.setChartMode(CHART_MODES.MAP);
 
     // fetch initial data
     props.getAggregateYearData();

--- a/src/state/actions/selections.js
+++ b/src/state/actions/selections.js
@@ -7,7 +7,6 @@ import {
 } from './data';
 
 import {
-  setChartModeInStorage,
   setDataModeInStorage,
 } from '../../utils';
 
@@ -393,7 +392,6 @@ export const setDataMode = (mode) => {
  */
 export const setChartMode = (mode) => {
   return (dispatch) => {
-    setChartModeInStorage(mode);
     dispatch({ type: ActionTypes.SET_CHART_MODE, payload: mode });
   };
 };


### PR DESCRIPTION
# map view renders first

disconnect from local storage so that map view renders first regardless of what mode the website was last closed on. map view (on historical data page) always renders first regardless. 

## Tickets

- [556](https://app.zenhub.com/workspaces/pine-beetle-prediction-tool-5d8ab1b0022c8d0001c05ba8/issues/dali-lab/pine-beetle-frontend/556)
