### PR TITLE
fixing reloading on local and deployment

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -48,6 +48,9 @@ const FallBack = () => {
   return <div>URL not found</div>;
 };
 
+global.API_URL = getServerUrl();
+global.AUTOMATION_API_URL = getAutomationServerUrl();
+
 const App = (props) => {
   const {
     loginUserFromStorage,

--- a/src/screens/prediction/components/prediction-map/component.js
+++ b/src/screens/prediction/components/prediction-map/component.js
@@ -487,17 +487,17 @@ const PredictionMap = (props) => {
     <div className="container flex-item-left" id="map-container">
       <div id="map" />
       <div className="map-overlay-data" id="data">
-        <h3 className="data-title">{data.length === 1
+        <h3 className="data-title">{data?.length === 1
           ? windowTitle()
           : 'Select county or federal land on the map to view prediction data'
         }
         </h3>
-        {data.length === 1
+        {data?.length === 1
           && <p>{year} Prediction</p>
         }
         <div className="data-info">
           <div className="data-info-section">
-            {data.length === 1
+            {data?.length === 1
               ? (
                 <div className="circle" id="any-spots">
                   <div id="percent">{((data[0].probSpotsGT0) * 100).toFixed(1)}%</div>
@@ -508,7 +508,7 @@ const PredictionMap = (props) => {
             <p>Predicted % Chance of Any Spots ({'>'}0 spots)</p>
           </div>
           <div className="data-info-section">
-            {data.length === 1
+            {data?.length === 1
               ? (
                 <div className="circle" id="outbreak">
                   <div id="percent">{((data[0].probSpotsGT50) * 100).toFixed(1)}%</div>
@@ -519,7 +519,7 @@ const PredictionMap = (props) => {
             <p>Predicted % Chance of Outbreak ({'>'}50 spots)</p>
           </div>
           <div className="data-info-section">
-            {data.length === 1
+            {data?.length === 1
               ? (
                 <div className="circle" id={data[0].hasSpotst0 === 1 && data[0].expSpotsIfOutbreak ? 'convergence' : 'empty'}>
                   {data[0].hasSpotst0 === 1 && data[0].expSpotsIfOutbreak
@@ -533,7 +533,7 @@ const PredictionMap = (props) => {
             <p>% Divergence of outcome from prediction</p>
           </div>
         </div>
-        {data.length === 1
+        {data?.length === 1
           && (
           <div className="data-button" onClick={() => setPredictionModal(true)}>
             <p>View details</p>

--- a/src/screens/trapping-data/components/trapping-data-map/component.js
+++ b/src/screens/trapping-data/components/trapping-data-map/component.js
@@ -511,17 +511,17 @@ const HistoricalMap = (props) => {
     <div id="trapping-map-container">
       <div id="map" />
       <div className="map-overlay-data" id="historical-data-overlay">
-        <h3 className="data-title">{rawData.length === 1
+        <h3 className="data-title">{rawData?.length === 1
           ? windowTitle()
           : 'Select county or federal land on the map to view historical data'
         }
         </h3>
-        {rawData.length === 1
+        {rawData?.length === 1
           && <p>{startYear}-{endYear}</p>
         }
         <div className="data-info-historical">
           <div className="data-info-section">
-            {rawData.length === 1
+            {rawData?.length === 1
               ? (
                 <div className="circle" id="spbs">
                   <div id="percent">{rawData[0].avgSpbPer2Weeks ? rawData[0].avgSpbPer2Weeks.toFixed(2) : 'n/a'}</div>
@@ -532,7 +532,7 @@ const HistoricalMap = (props) => {
             <p>Average SPB per 2 weeks</p>
           </div>
           <div className="data-info-section">
-            {rawData.length === 1
+            {rawData?.length === 1
               ? (
                 <div className="circle" id="clerid">
                   <div id="percent">{rawData[0].avgCleridsPer2Weeks ? rawData[0].avgCleridsPer2Weeks.toFixed(2) : 'n/a'}</div>
@@ -543,7 +543,7 @@ const HistoricalMap = (props) => {
             <p>Average clerids per 2 weeks</p>
           </div>
           <div className="data-info-section">
-            {rawData.length === 1
+            {rawData?.length === 1
               ? (
                 <div className="circle" id={overlaySpotsColor(rawData[0].sumSpotst0)}>
                   <div id="percent">{rawData[0].sumSpotst0.toFixed(0)}</div>


### PR DESCRIPTION
# Description

I wasn't able to test this yet because this bug works differently between local and netlify, at least for me.

1. On local, reloading the page on any map page would cause a lot of fetch errors. This is fixed by moving global API URL outside of the useEffect scope so it happens earlier.2. 
1. On netlify, the app crashes upon reload on a map page. I suspect this is because there's no data null/undefined guard in the render functions, and I added optional chaining to help with that. I cannot test this one right now b/c it needs to be deployed for the bug to happen.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

## Screenshots

Please attach any design screenshots if UI update.
