### PR TITLE
Fixed bug with lost states on prediction

### DIFF
--- a/src/components/input-components/multi-select-input/component.js
+++ b/src/components/input-components/multi-select-input/component.js
@@ -84,7 +84,7 @@ const MultiSelectInput = (props) => {
       <div className="location-list">
         <div className="location-list-header">
           <p className="location-list-instructions">Select location(s)</p>
-          <div className="location-list-clear" onClick={() => clearAllSelections()}>clear</div>
+          <div className="location-list-clear" onClick={clearAllSelections}>clear</div>
         </div>
         {optionsParent.map(item => (
           <div

--- a/src/state/actions/selections.js
+++ b/src/state/actions/selections.js
@@ -88,6 +88,7 @@ export function getAvailableStates(overrideFilter = {}, { historical = true, pre
       endYear,
       startYear,
       predictionYear,
+      chartMode,
     } = getState().selections;
 
     const filters = {
@@ -105,7 +106,7 @@ export function getAvailableStates(overrideFilter = {}, { historical = true, pre
 
       if (prediction) {
         let predictionStates = [];
-        if (getState().selections.chartMode === CHART_MODES.MAP) {
+        if (chartMode === CHART_MODES.MAP) {
           predictionStates = await api.getAvailableStates(dataMode, {
             ...filters,
             isPrediction: true,

--- a/src/state/reducers/selections.js
+++ b/src/state/reducers/selections.js
@@ -3,8 +3,8 @@ import { DATA_MODES, CHART_MODES } from '../../constants';
 
 const initialState = {
   startYear: 1988,
-  endYear: new Date().getFullYear(),
-  predictionYear: new Date().getFullYear(),
+  endYear: 2021,
+  predictionYear: 2021, // new Date().getFullYear() was 2022, leading to empty state data for now
   state: '',
   county: [],
   rangerDistrict: [],


### PR DESCRIPTION
# Description

It turns out the prediction map was getting info for the prediction year of 2022, for which we don't have data. I switched the default end year and prediction year to be 2021 for now, and it might need to be updated if more data is added.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update