### PR TITLE
styling of toggles to match figma

### DIFF
--- a/src/screens/prediction/style.scss
+++ b/src/screens/prediction/style.scss
@@ -18,21 +18,20 @@
     display: flex;
     position: absolute;
     margin-top: 2px;
-    left: 32vw;
+    left: 35vw;
     z-index: 1;
 }
 
 .selection-p {
     display: flex;
     flex-direction: row;
-    justify-content: space-evenly;
+    justify-content: space-between;
     align-items: center;
-    width: 300px;
-    height: 40px;
-    background-color: #FFFFFF;
+    height: 30px;
+    background-color: #F4F4F4;
+    box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.25), 1px 1.5px 4px grey inset;
     border-radius: 100px;
-    border: 1px solid #B7B7B7;
-    box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.25);
+    border: 4px solid #FFFFFF;
     margin-top: 2vh;
     margin-left: 1vw;
 
@@ -44,6 +43,8 @@
         border-radius: 100px;
         padding-left: 25px;
         padding-right: 25px;
+        padding-top: 1.4px;
+        padding-bottom: 1.4px;
 
         .selected-option-text-p {
             color: #ffffff;
@@ -61,6 +62,8 @@
         border-radius: 100px;
         padding-left: 15px;
         padding-right: 15px;
+        padding-top: 1.4px;
+        padding-bottom: 1.4px;
 
         .selected-option-text-p {
             color: #ffffff;
@@ -77,7 +80,6 @@
         align-items: center;
         padding-left: 15px;
         padding-right: 15px;
-        box-shadow: 1px 1.5px 4px grey inset;
         border-radius: 100px;
         cursor: pointer;
 

--- a/src/screens/trapping-data/style.scss
+++ b/src/screens/trapping-data/style.scss
@@ -9,22 +9,22 @@
     display: flex;
     position: absolute;
     margin-top: 5px;
-    left: 31vw;
+    left: 35vw;
     z-index: 1;
 }
 
 .selection {
     display: flex;
     flex-direction: row;
-    justify-content: space-evenly;
+    justify-content: space-between;
     align-items: center;
-    width: 300px;
-    height: 40px;
-    background-color: #FFFFFF;
+    height: 30px;
+    background-color: #F4F4F4;
+    box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.25), 1px 1.5px 4px grey inset;
     border-radius: 100px;
-    border: 1px solid #B7B7B7;
-    box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.25);
-    margin-left: 2vw;
+    border: 4px solid #FFFFFF;
+    margin-top: 2vh;
+    margin-left: 1vw;
 
     .selected-option {
         display: flex;
@@ -34,6 +34,8 @@
         border-radius: 100px;
         padding-left: 25px;
         padding-right: 25px;
+        padding-top: 1.4px;
+        padding-bottom: 1.4px;
 
         .selected-option-text {
             color: #ffffff;
@@ -51,6 +53,8 @@
         border-radius: 100px;
         padding-left: 15px;
         padding-right: 15px;
+        padding-top: 1.4px;
+        padding-bottom: 1.4px;
 
         .selected-option-text {
             color: #ffffff;
@@ -67,7 +71,6 @@
         align-items: center;
         padding-left: 15px;
         padding-right: 15px;
-        box-shadow: 1px 1.5px 4px grey inset;
         border-radius: 100px;
         cursor: pointer;
 


### PR DESCRIPTION
# change styling of toggles to match figma

make toggles look more like a slider rather than two buttons. changed on both the prediction and historical data page

## Screenshots

Please attach any design screenshots if UI update.
<img width="586" alt="Capture" src="https://user-images.githubusercontent.com/13407296/160031358-8c7b3319-f729-420a-95e2-41d49df5c907.PNG">

