### PR TITLE
fixes wrong circle color when there is no spot data

### DIFF
--- a/src/screens/trapping-data/components/trapping-data-map/component.js
+++ b/src/screens/trapping-data/components/trapping-data-map/component.js
@@ -551,10 +551,15 @@ const HistoricalMap = (props) => {
             {
               rawData?.length === 1
                 ? (
-                  <div className="circle" id={overlaySpotsColor(rawData[0].sumSpotst0 / numYears)}>
-                    <div id="percent">{rawData[0].sumSpotst0.toFixed(0)}</div>
+                  <div className="circle" id={rawData[0].hasSpotst0 === 1 ? overlaySpotsColor(rawData[0].sumSpotst0 / numYears) : overlaySpotsColor(null)}>
+                    {
+                      rawData[0].hasSpotst0 === 1
+                        ? <div id="percent">{rawData[0].sumSpotst0.toFixed(0)}</div>
+                        : <div id="percent">n/a</div>
+                    }
                   </div>
                 )
+
                 : <div className="circle" id="empty" />
             }
             <p>Total number of spots</p>


### PR DESCRIPTION
# Description

Closes #600. When there is no spot data, the circle's color should be gray with the text "n/a" instead of blue with the text "0".

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- #600 

## Screenshots

Please attach any design screenshots if UI update.
