### PR TITLE
fix: add api url to image path in blog edit

### DIFF
--- a/src/screens/admin/components/blog-post-form/component.js
+++ b/src/screens/admin/components/blog-post-form/component.js
@@ -95,7 +95,7 @@ const BlogPostForm = (props) => {
           />
           {typeof formData.image === 'string' && (
           <div className="image-preview-container">
-            <img src={formData.image} alt="blog post illustration" />
+            <img src={`${global.API_URL}${formData.image}`} alt="blog post illustration" />
           </div>
           )}
         </div>

--- a/src/screens/admin/components/blog-post-form/style.scss
+++ b/src/screens/admin/components/blog-post-form/style.scss
@@ -78,6 +78,7 @@
     height: 150px;
     overflow: hidden;
     position: relative;
+    border-radius: 10px;
 
     img {
         position: absolute;


### PR DESCRIPTION
# Description

Pictures weren't displaying in edit form, because the api url was lacking in the path.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Trello](https://trello.com/c/B5p8paIS)

## Screenshots

Please attach any design screenshots if UI update.
