### PR TITLE
Feat/add probability histogram

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "axios": "^1.2.1",
         "chart.js": "^2.9.4",
         "chartjs-top-round-bar": "^1.0.1",
+        "echarts": "^5.6.0",
+        "echarts-for-react": "^3.0.2",
         "mapbox-gl": "^2.11.1",
         "mapbox-print-pdf": "^0.4.3",
         "prop-types": "^15.8.1",
@@ -5044,6 +5046,34 @@
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.2.tgz",
+      "integrity": "sha512-DRwIiTzx8JfwPOVgGttDytBqdp5VzCSyMRIxubgU/g2n9y3VLUmF2FK7Icmg/sNVkv4+rktmrLN9w22U2yy3fA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -6139,8 +6169,7 @@
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -11707,6 +11736,11 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.2.tgz",
+      "integrity": "sha512-2NCmWxY7A9pYKGXNBfteo4hy14gWu47rg5692peVMst6lQLPKrVjhY+UTEsPI5ceFRJSl3gVgMYaUi/hKuaiKw=="
+    },
     "node_modules/slash": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
@@ -14012,6 +14046,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,8 @@
     "axios": "^1.2.1",
     "chart.js": "^2.9.4",
     "chartjs-top-round-bar": "^1.0.1",
+    "echarts": "^5.6.0",
+    "echarts-for-react": "^3.0.2",
     "mapbox-gl": "^2.11.1",
     "mapbox-print-pdf": "^0.4.3",
     "prop-types": "^15.8.1",

--- a/src/components/histogram-components/histogram/component.js
+++ b/src/components/histogram-components/histogram/component.js
@@ -3,7 +3,27 @@ import SingleChart from '../single-chart/component';
 
 import './style.scss';
 
-const Histogram = () => {
+const Histogram = ({ frequencyArray }) => {
+  const getXAxisLegend = () => {
+    const legend = frequencyArray.map((item) => {
+      const rangeArray = item.range.split('-');
+
+      if (rangeArray[0] === '0') {
+        return `< ${rangeArray[1] * 100}%`;
+      } else if (rangeArray[1] === '1') {
+        return `> ${rangeArray[0] * 100}%`;
+      }
+
+      return `${rangeArray[0] * 100} - ${rangeArray[1] * 100}%`;
+    });
+    return legend;
+  };
+
+  // the max value for the x axis of single chart
+  const globalMax = Math.ceil(
+    Math.max(...frequencyArray.flatMap((item) => item.data)) / 100,
+  ) * 100; // calculate the max value from all the histogram data and round it up to the nearest multiple of 100
+
   return (
     <div className="histogram">
       <div className="histogram__legend-container">
@@ -22,24 +42,22 @@ const Histogram = () => {
       </div>
       <div>
         <div className="histogram__wrapper">
-          <SingleChart />
-          <SingleChart />
-          <SingleChart />
-          <SingleChart withBorder />
-          <SingleChart />
-          <SingleChart />
-          <SingleChart />
-          <SingleChart />
+          {frequencyArray.map((item, index) => (
+            <SingleChart
+              key={`histogramBin-${index + 1}`}
+              frequency={item.frequency}
+              withBorder={item.withBorder}
+              globalMax={globalMax}
+              data={item.data}
+            />
+          ))}
         </div>
         <div className="histogram__legend--x-axis">
-          <p>{'< 2,5%'}</p>
-          <p>2,5 - 5%</p>
-          <p>5 - 15%</p>
-          <p>15 - 25%</p>
-          <p>25 - 40%</p>
-          <p>40 - 60%</p>
-          <p>60 - 80%</p>
-          <p>{'> 80%'}</p>
+          {getXAxisLegend().map((item, index) => (
+            <p key={`legendBin-${index + 1}`}>
+              {item}
+            </p>
+          ))}
         </div>
         <h4 className="histogram__x-axis-title">
           {'Predicted % chance of > 50 spots'}

--- a/src/components/histogram-components/histogram/component.js
+++ b/src/components/histogram-components/histogram/component.js
@@ -1,69 +1,89 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import SingleChart from '../single-chart/component';
+import Loader from '../../loader';
 
 import './style.scss';
 
-const Histogram = ({ frequencyArray }) => {
+const updateWithBorder = (array, probSpotsGT50) => {
+  const arrayUpdated = array.map((item) => {
+    const rangeArray = item.range.split('-');
+
+    if (probSpotsGT50 >= rangeArray[0] && probSpotsGT50 < rangeArray[1]) {
+      return { ...item, withBorder: true };
+    } else return item;
+  });
+
+  return arrayUpdated;
+};
+
+const Histogram = ({ histogramData, getHistogram, probSpotsGT50 }) => {
+  useEffect(() => getHistogram(), [getHistogram]);
+
+  const updatedHistogramData = updateWithBorder(histogramData, probSpotsGT50);
+
   const getXAxisLegend = () => {
-    const legend = frequencyArray.map((item) => {
-      const rangeArray = item.range.split('-');
+    if (updatedHistogramData) {
+      const legend = updatedHistogramData.map((item) => {
+        const rangeArray = item.range.split('-');
 
-      if (rangeArray[0] === '0') {
-        return `< ${rangeArray[1] * 100}%`;
-      } else if (rangeArray[1] === '1') {
-        return `> ${rangeArray[0] * 100}%`;
-      }
+        if (rangeArray[0] === '0') {
+          return `< ${rangeArray[1] * 100}%`;
+        } else if (rangeArray[1] === '1') {
+          return `> ${rangeArray[0] * 100}%`;
+        }
 
-      return `${rangeArray[0] * 100} - ${rangeArray[1] * 100}%`;
-    });
-    return legend;
+        return `${rangeArray[0] * 100} - ${rangeArray[1] * 100}%`;
+      });
+      return legend;
+    }
+    return [];
   };
 
-  // the max value for the x axis of single chart
-  const globalMax = Math.ceil(
-    Math.max(...frequencyArray.flatMap((item) => item.data)) / 100,
-  ) * 100; // calculate the max value from all the histogram data and round it up to the nearest multiple of 100
-
   return (
-    <div className="histogram">
-      <div className="histogram__legend-container">
-        <h4 className="histogram__y-axis-title">Observed number of spots</h4>
-        <div className="histogram__legend histogram__legend--yellow">
-          <p>{'> 249'}</p>
-          <p>100 - 249</p>
-          <p>50 - 99</p>
+    updatedHistogramData.length > 0 ? (
+      <div className="histogram">
+        <div className="histogram__legend-container">
+          <h4 className="histogram__y-axis-title">Observed number of spots</h4>
+          <div className="histogram__legend histogram__legend--yellow">
+            <p>{'> 249'}</p>
+            <p>100 - 249</p>
+            <p>50 - 99</p>
+          </div>
+          <div className="histogram__legend histogram__legend--blue">
+            <p>20 - 49</p>
+            <p>10 - 19</p>
+            <p>1 - 9</p>
+            <p>0</p>
+          </div>
         </div>
-        <div className="histogram__legend histogram__legend--blue">
-          <p>20 - 49</p>
-          <p>10 - 19</p>
-          <p>1 - 9</p>
-          <p>0</p>
+        <div>
+          <div className="histogram__wrapper">
+            {updatedHistogramData.map((item, index) => (
+              <SingleChart
+                key={`histogramBin-${index + 1}`}
+                frequency={item.frequency}
+                withBorder={item.withBorder}
+                data={item.data}
+              />
+            ))}
+          </div>
+          <div className="histogram__legend--x-axis">
+            {getXAxisLegend().map((item, index) => (
+              <p key={`legendBin-${index + 1}`}>
+                {item}
+              </p>
+            ))}
+          </div>
+          <h4 className="histogram__x-axis-title">
+            {'Predicted % chance of > 50 spots'}
+          </h4>
         </div>
       </div>
-      <div>
-        <div className="histogram__wrapper">
-          {frequencyArray.map((item, index) => (
-            <SingleChart
-              key={`histogramBin-${index + 1}`}
-              frequency={item.frequency}
-              withBorder={item.withBorder}
-              globalMax={globalMax}
-              data={item.data}
-            />
-          ))}
-        </div>
-        <div className="histogram__legend--x-axis">
-          {getXAxisLegend().map((item, index) => (
-            <p key={`legendBin-${index + 1}`}>
-              {item}
-            </p>
-          ))}
-        </div>
-        <h4 className="histogram__x-axis-title">
-          {'Predicted % chance of > 50 spots'}
-        </h4>
+    ) : (
+      <div className="histogram__loader">
+        <Loader />
       </div>
-    </div>
+    )
   );
 };
 

--- a/src/components/histogram-components/histogram/component.js
+++ b/src/components/histogram-components/histogram/component.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import SingleChart from '../single-chart/component';
+
+import './style.scss';
+
+const Histogram = () => {
+  return (
+    <div className="histogram">
+      <div className="histogram__legend-container">
+        <h4 className="histogram__y-axis-title">Observed number of spots</h4>
+        <div className="histogram__legend histogram__legend--yellow">
+          <p>{'> 249'}</p>
+          <p>100 - 249</p>
+          <p>50 - 99</p>
+        </div>
+        <div className="histogram__legend histogram__legend--blue">
+          <p>20 - 49</p>
+          <p>10 - 19</p>
+          <p>1 - 9</p>
+          <p>0</p>
+        </div>
+      </div>
+      <div>
+        <div className="histogram__wrapper">
+          <SingleChart />
+          <SingleChart />
+          <SingleChart />
+          <SingleChart withBorder />
+          <SingleChart />
+          <SingleChart />
+          <SingleChart />
+          <SingleChart />
+        </div>
+        <div className="histogram__legend--x-axis">
+          <p>{'< 2,5%'}</p>
+          <p>2,5 - 5%</p>
+          <p>5 - 15%</p>
+          <p>15 - 25%</p>
+          <p>25 - 40%</p>
+          <p>40 - 60%</p>
+          <p>60 - 80%</p>
+          <p>{'> 80%'}</p>
+        </div>
+        <h4 className="histogram__x-axis-title">
+          {'Predicted % chance of > 50 spots'}
+        </h4>
+      </div>
+    </div>
+  );
+};
+
+export default Histogram;

--- a/src/components/histogram-components/histogram/index.js
+++ b/src/components/histogram-components/histogram/index.js
@@ -1,0 +1,30 @@
+import { connect } from 'react-redux';
+
+import { getHistogram } from '../../../state/actions';
+
+import Histogram from './component';
+
+const mapStateToProps = (state) => {
+  const {
+    histogram: {
+      histogramData,
+    },
+  } = state;
+
+  return {
+    histogramData,
+  };
+};
+
+const mapDispatchToProps = (dispatch) => {
+  return {
+    getHistogram: () => {
+      dispatch(getHistogram());
+    },
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Histogram);

--- a/src/components/histogram-components/histogram/style.scss
+++ b/src/components/histogram-components/histogram/style.scss
@@ -65,3 +65,8 @@
     border-bottom: 3px solid black;
     min-width: 450px;
 }
+
+.histogram__loader {
+    width: 20%;
+    margin: auto;
+}

--- a/src/components/histogram-components/histogram/style.scss
+++ b/src/components/histogram-components/histogram/style.scss
@@ -1,0 +1,67 @@
+.histogram {
+    display: flex;
+    margin-bottom: 40px;
+}
+
+.histogram__y-axis-title {
+    position: absolute;
+    writing-mode: vertical-lr;
+    transform: rotate(180deg);
+    left: 0;
+    top: 50px;
+    font-weight: 500;
+}
+
+.histogram__legend-container {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+    position:relative;
+    width: 130px;
+    height: auto;
+    padding-top: 26px;
+}
+
+.histogram__legend {
+    padding-right: 10px;
+    border-radius: 5px;
+    margin-right: 10px;
+    margin-left: 30px;
+    width: 75px;
+
+    p {
+        font-size: 14px;
+        line-height: 31px;
+        text-align: right;
+    }
+}
+
+.histogram__legend--yellow {
+    background-color: $yellow;
+    padding-top: 5px;
+}
+
+.histogram__legend--blue {
+    background-color: $blue500;
+    padding-bottom: 5px;
+}
+
+.histogram__legend--x-axis {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    font-size: 13px;
+    padding: 15px 10px;
+}
+
+.histogram__x-axis-title {
+    font-weight: 500;
+}
+
+.histogram__wrapper {
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    padding: 10px;
+    border-left: 3px solid black;
+    border-bottom: 3px solid black;
+    min-width: 450px;
+}

--- a/src/components/histogram-components/single-chart/component.js
+++ b/src/components/histogram-components/single-chart/component.js
@@ -1,0 +1,85 @@
+import React from 'react';
+import ReactECharts from 'echarts-for-react';
+import './style.scss';
+
+const SingleChart = ({ withBorder }) => {
+  const options = {
+    grid: {
+      top: 10,
+      bottom: 10,
+      left: 10,
+      right: 10,
+      containLabel: false,
+    },
+    yAxis: {
+      type: 'category',
+      data: ['0', '1-9', '10-19', '20-49', '50-99', '100-249', '>249'],
+      axisLine: {
+        show: true,
+        lineStyle: { color: '#000', width: 2 },
+      },
+      axisTick: {
+        show: true,
+        alignWithLabel: true,
+        lineStyle: { color: '#000', width: 1.5 },
+        length: 10,
+      },
+      axisLabel: {
+        show: false,
+      },
+      boundaryGap: true,
+    },
+    xAxis: {
+      type: 'value',
+      axisLine: {
+        show: true,
+        lineStyle: { color: '#000', width: 1.3 },
+      },
+      axisTick: {
+        show: true,
+        length: 5, // Big ticks
+        inside: false,
+        lineStyle: { color: '#000', width: 1 },
+      },
+      splitLine: { show: false },
+      axisLabel: { show: false },
+      minorTick: {
+        show: true,
+        splitNumber: 4, // 3 smaller ticks between big ticks
+        length: 3,
+        lineStyle: { color: '#000', width: 0.5 },
+      },
+    },
+    series: [
+      {
+        name: 'Spots',
+        type: 'bar',
+        data: [200, 50, 80, 100, 200, 250, 300],
+        barWidth: '98%',
+        barCategoryGap: '1%',
+        itemStyle: {
+          color: (params) => {
+            const categoriesAbove50 = ['>249', '100-249', '50-99'];
+            return categoriesAbove50.includes(params.name)
+              ? '#FFC148'
+              : '#86CCFF';
+          },
+          borderRadius: [0, 5, 5, 0],
+        },
+      },
+    ],
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+    },
+  };
+
+  return (
+    <div className={`single-chart-wrapper ${withBorder && 'with-border'}`}>
+      <ReactECharts option={options} style={{ height: 250, width: 'auto' }} />
+      <p className="single-chart__text">Frequency (n&nbsp;=&nbsp;1517)</p>
+    </div>
+  );
+};
+
+export default SingleChart;

--- a/src/components/histogram-components/single-chart/component.js
+++ b/src/components/histogram-components/single-chart/component.js
@@ -2,7 +2,12 @@ import React from 'react';
 import ReactECharts from 'echarts-for-react';
 import './style.scss';
 
-const SingleChart = ({ withBorder }) => {
+const SingleChart = ({
+  withBorder,
+  frequency,
+  globalMax,
+  data,
+}) => {
   const options = {
     grid: {
       top: 10,
@@ -16,24 +21,26 @@ const SingleChart = ({ withBorder }) => {
       data: ['0', '1-9', '10-19', '20-49', '50-99', '100-249', '>249'],
       axisLine: {
         show: true,
-        lineStyle: { color: '#000', width: 2 },
+        lineStyle: { color: '#000', width: 1 },
+        onZero: false,
       },
       axisTick: {
         show: true,
         alignWithLabel: true,
-        lineStyle: { color: '#000', width: 1.5 },
+        lineStyle: { color: '#000', width: 1 },
         length: 10,
       },
       axisLabel: {
         show: false,
       },
       boundaryGap: true,
+      offset: 1,
     },
     xAxis: {
       type: 'value',
       axisLine: {
         show: true,
-        lineStyle: { color: '#000', width: 1.3 },
+        lineStyle: { color: '#000', width: 1 },
       },
       axisTick: {
         show: true,
@@ -47,14 +54,15 @@ const SingleChart = ({ withBorder }) => {
         show: true,
         splitNumber: 4, // 3 smaller ticks between big ticks
         length: 3,
-        lineStyle: { color: '#000', width: 0.5 },
+        lineStyle: { color: '#000', width: 1 },
       },
+      max: globalMax,
     },
     series: [
       {
         name: 'Spots',
         type: 'bar',
-        data: [200, 50, 80, 100, 200, 250, 300],
+        data,
         barWidth: '98%',
         barCategoryGap: '1%',
         itemStyle: {
@@ -77,7 +85,9 @@ const SingleChart = ({ withBorder }) => {
   return (
     <div className={`single-chart-wrapper ${withBorder && 'with-border'}`}>
       <ReactECharts option={options} style={{ height: 250, width: 'auto' }} />
-      <p className="single-chart__text">Frequency (n&nbsp;=&nbsp;1517)</p>
+      <p className="single-chart__text">
+        Frequency (n&nbsp;=&nbsp;{frequency})
+      </p>
     </div>
   );
 };

--- a/src/components/histogram-components/single-chart/component.js
+++ b/src/components/histogram-components/single-chart/component.js
@@ -5,7 +5,6 @@ import './style.scss';
 const SingleChart = ({
   withBorder,
   frequency,
-  globalMax,
   data,
 }) => {
   const options = {
@@ -56,11 +55,11 @@ const SingleChart = ({
         length: 3,
         lineStyle: { color: '#000', width: 1 },
       },
-      max: globalMax,
+      max: data.frequency,
     },
     series: [
       {
-        name: 'Spots',
+        name: 'Frequency',
         type: 'bar',
         data,
         barWidth: '98%',

--- a/src/components/histogram-components/single-chart/style.scss
+++ b/src/components/histogram-components/single-chart/style.scss
@@ -1,0 +1,12 @@
+.single-chart-wrapper {
+    padding: 7px;
+
+    &.with-border {
+        border-radius: 10px;
+        box-shadow: 0 0 0 3px black;
+    }
+}
+
+.single-chart__text {
+    font-size: 10px;
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,6 +2,8 @@ import Button from './button';
 import DownloadData from './download-data';
 import Footer from './footer';
 import Header from './header';
+import Histogram from './histogram-components/histogram';
+import Loader from './loader';
 import Loading from './loading';
 import MobileOverlay from './mobile-overlay';
 import ScrollToTop from './scroll-to-top';
@@ -11,6 +13,8 @@ export {
   DownloadData,
   Footer,
   Header,
+  Histogram,
+  Loader,
   Loading,
   MobileOverlay,
   ScrollToTop,

--- a/src/components/loader/index.js
+++ b/src/components/loader/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import Lottie from 'react-lottie';
+
+import animationData from '../../assets/animations/loading.json';
+
+const defaultOptions = {
+  loop: true,
+  autoplay: true,
+  animationData,
+  rendererSettings: {
+    preserveAspectRatio: 'xMidYMid slice',
+  },
+};
+
+const Loader = () => {
+  return (
+    <Lottie
+      options={defaultOptions}
+      isClickToPauseDisabled
+    />
+  );
+};
+
+export default Loader;

--- a/src/components/loading/index.js
+++ b/src/components/loading/index.js
@@ -1,19 +1,8 @@
 import React from 'react';
-import Lottie from 'react-lottie';
 import Modal from 'react-modal';
-
-import animationData from '../../assets/animations/loading.json';
+import Loader from '../loader';
 
 import './style.scss';
-
-const defaultOptions = {
-  loop: true,
-  autoplay: true,
-  animationData,
-  rendererSettings: {
-    preserveAspectRatio: 'xMidYMid slice',
-  },
-};
 
 const Loading = ({ visible }) => {
   return (
@@ -27,10 +16,7 @@ const Loading = ({ visible }) => {
       <div id="loading-container">
         <p>Please wait while we load the data...</p>
         <div id="loading-animation">
-          <Lottie
-            options={defaultOptions}
-            isClickToPauseDisabled
-          />
+          <Loader />
         </div>
       </div>
     </Modal>

--- a/src/screens/admin/component.js
+++ b/src/screens/admin/component.js
@@ -10,7 +10,7 @@ import {
   Users,
 } from './components';
 
-import { runPipeline } from '../../services/admin';
+import { runPipeline, updateHistogram } from '../../services/admin';
 
 import './style.scss';
 
@@ -30,9 +30,12 @@ const Admin = (props) => {
 
   const [changePasswordVisible, setChangePasswordVisible] = useState(false);
   const [runningModels, setRunningModels] = useState(false);
+  const [updatingHistogram, setUpdatingHistogram] = useState(false);
   const [modelError, setModelError] = useState('');
+  const [histogramError, setHistogramError] = useState('');
 
   const runAllModels = async () => {
+    setModelError('');
     setRunningModels(true);
 
     try {
@@ -41,6 +44,19 @@ const Admin = (props) => {
       setModelError(err?.response?.data?.error?.message || '');
     } finally {
       setRunningModels(false);
+    }
+  };
+
+  const runUpdateHistogram = async () => {
+    setHistogramError('');
+    setUpdatingHistogram(true);
+
+    try {
+      await updateHistogram();
+    } catch (err) {
+      setHistogramError(err?.response?.data || '');
+    } finally {
+      setUpdatingHistogram(false);
     }
   };
 
@@ -66,20 +82,41 @@ const Admin = (props) => {
               <div id="add-users"><AddUser /></div>
             </div>
           </div>
-          <button
-            className="animated-button"
-            disabled={runningModels}
-            id="rerun-button"
-            onClick={runAllModels}
-            type="button"
-          >
-            {runningModels ? 'Running...' : 'Rerun all models'}
-          </button>
-          {modelError && (
-            <div id="model-error-container">
-              <p>{modelError}</p>
+          <div className="dashboard-buttons-container">
+            <div className="button">
+              <button
+                className="animated-button"
+                disabled={runningModels}
+                id="rerun-button"
+                onClick={runAllModels}
+                type="button"
+              >
+                {runningModels ? 'Running...' : 'Rerun all models'}
+              </button>
+              {modelError && (
+              <div id="model-error-container">
+                <p>{modelError}</p>
+              </div>
+              )}
             </div>
-          )}
+            <div className="button">
+              <button
+                className="animated-button"
+                disabled={updatingHistogram}
+                id="update-histogram-button"
+                onClick={runUpdateHistogram}
+                type="button"
+              >
+                {updatingHistogram ? 'Updating...' : 'Update histogram'}
+              </button>
+              {histogramError && (
+              <div id="histogram-error-container">
+                <span className="error-mark">!</span>
+                <p>{histogramError}</p>
+              </div>
+              )}
+            </div>
+          </div>
           <div className="blog-container">
             <AddBlogPost />
             <BlogPosts />

--- a/src/screens/admin/style.scss
+++ b/src/screens/admin/style.scss
@@ -91,17 +91,50 @@
             }
         }
 
-        #rerun-button {
-            margin: 40px 346px 40px 349px;
-            padding: 8px 34px 7px 35px;
-            border-radius: 6px;
-            background-color: $greyBlue900;
-            font-size: 18px;
-            font-weight: 600;
-            line-height: 1.8;
-            color: $white;
-            white-space: nowrap;
+        .dashboard-buttons-container {
+            display:flex;
+            justify-content: space-around;
+            margin: 40px;
+
+            .button {
+                flex: 0
+            }
+
+            #rerun-button,
+            #update-histogram-button {
+                margin: 20px 40px;
+                padding: 8px 34px 7px 35px;
+                border-radius: 6px;
+                background-color: $greyBlue900;
+                font-size: 18px;
+                font-weight: 600;
+                line-height: 1.8;
+                color: $white;
+                white-space: nowrap;
+            }
+
+            #model-error-container,
+            #histogram-error-container {
+                color: $red500;
+                display: flex;
+                justify-content: center;
+                font-weight: 700;
+
+                .error-mark {
+                    width: 30px;
+                    height: 30px;
+                    display: flex;
+                    align-items: center;
+                    justify-content: center;
+                    border-radius: 100%;
+                    flex: 0 0 auto;
+                    background-color: $red500;
+                    color: $white;
+                    margin-right: 10px;
+                }
+            }
         }
+
     }
 }
 

--- a/src/screens/home/components/play-with-model/components/play-with-model-outputs/component.js
+++ b/src/screens/home/components/play-with-model/components/play-with-model-outputs/component.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { getFillColor } from '../../../../../../utils';
 
 import './style.scss';
 
@@ -34,7 +35,10 @@ const PlayWithModelOutputs = (props) => {
 
   const predictionDetails = () => (
     <>
-      <div id={showPredictions ? 'prob-spots' : 'prob-spots-disabled'}>
+      <div
+        id={showPredictions ? 'prob-spots' : 'prob-spots-disabled'}
+        className={showPredictions && `color-fill-with-shadow ${getFillColor(probSpots).colorName}`}
+      >
         <div id="percent">
           {showPredictions
             ? `${(probSpots * 100).toFixed(1)}%`
@@ -44,7 +48,10 @@ const PlayWithModelOutputs = (props) => {
           <p>Predicted % Chance of Any Spots ({'>'}0 spots)</p>
         </div>
       </div>
-      <div id={showPredictions ? 'prob-outbreak' : 'prob-outbreak-disabled'}>
+      <div
+        id={showPredictions ? 'prob-outbreak' : 'prob-outbreak-disabled'}
+        className={showPredictions && `color-fill-with-shadow ${getFillColor(probOutbreak).colorName}`}
+      >
         <div id="percent">
           {showPredictions
             ? `${(probOutbreak * 100).toFixed(1)}%`

--- a/src/screens/home/components/play-with-model/components/play-with-model-outputs/style.scss
+++ b/src/screens/home/components/play-with-model/components/play-with-model-outputs/style.scss
@@ -38,22 +38,17 @@
             border-radius: 12px;
         }
 
-        #prob-spots,
-        #prob-spots-disabled {
-            box-shadow: 0 18px 50px 0 rgba(255, 193, 72, 0.4);
-            background-color: $yellow;
-        }
-
-        #prob-outbreak,
-        #prob-outbreak-disabled {
-            box-shadow: 0 18px 50px 0 rgba(134, 204, 255, 0.4);
-            background-color: $blue500;
-        }
-
         #prob-outbreak-disabled,
         #prob-spots-disabled {
             box-shadow: 0 18px 50px 0 rgba(49, 57, 85, 0.04);
             background-color: $greyBlue400;
+        }
+
+        .darkRed {
+            #percent,
+            #prob-text {
+                color: $white;
+            }
         }
     }
 

--- a/src/screens/prediction/component.js
+++ b/src/screens/prediction/component.js
@@ -17,12 +17,13 @@ import './style.scss';
 
 import closeIcon from '../../assets/icons/close.png';
 
-import histogrambin1 from '../../assets/images/spb-histogram-bin1.png';
-import histogrambin2 from '../../assets/images/spb-histogram-bin2.png';
-import histogrambin3 from '../../assets/images/spb-histogram-bin3.png';
-import histogrambin4 from '../../assets/images/spb-histogram-bin4.png';
-import histogrambin5 from '../../assets/images/spb-histogram-bin5.png';
-import histogrambin6 from '../../assets/images/spb-histogram-bin6.png';
+// import histogrambin1 from '../../assets/images/spb-histogram-bin1.png';
+// import histogrambin2 from '../../assets/images/spb-histogram-bin2.png';
+// import histogrambin3 from '../../assets/images/spb-histogram-bin3.png';
+// import histogrambin4 from '../../assets/images/spb-histogram-bin4.png';
+// import histogrambin5 from '../../assets/images/spb-histogram-bin5.png';
+// import histogrambin6 from '../../assets/images/spb-histogram-bin6.png';
+import Histogram from '../../components/histogram-components/histogram/component';
 
 const Prediction = (props) => {
   const {
@@ -56,26 +57,26 @@ const Prediction = (props) => {
     clearAllSelections(); // clears selections initially when switching to this tab
   }, [clearAllSelections]);
 
-  const getHistogram = (probSpotsGT50) => {
-    if (probSpotsGT50 < 0.025) {
-      return histogrambin1;
-    } else if (probSpotsGT50 < 0.05) {
-      return histogrambin2;
-    } else if (probSpotsGT50 < 0.15) {
-      return histogrambin3;
-    } else if (probSpotsGT50 < 0.25) {
-      return histogrambin4;
-    } else if (probSpotsGT50 < 0.4) {
-      return histogrambin5;
-    } else {
-      return histogrambin6;
-    }
-  };
+  // const getHistogram = (probSpotsGT50) => {
+  //   if (probSpotsGT50 < 0.025) {
+  //     return histogrambin1;
+  //   } else if (probSpotsGT50 < 0.05) {
+  //     return histogrambin2;
+  //   } else if (probSpotsGT50 < 0.15) {
+  //     return histogrambin3;
+  //   } else if (probSpotsGT50 < 0.25) {
+  //     return histogrambin4;
+  //   } else if (probSpotsGT50 < 0.4) {
+  //     return histogrambin5;
+  //   } else {
+  //     return histogrambin6;
+  //   }
+  // };
 
   const predModal = () => {
     if (!predictionModal) return null;
-    const { probSpotsGT50 } = data[0];
-    const histogram = getHistogram(probSpotsGT50);
+    // const { probSpotsGT50 } = data[0];
+    // const histogram = getHistogram(probSpotsGT50);
     return (
       <Modal
         isOpen={predictionModal}
@@ -92,16 +93,14 @@ const Prediction = (props) => {
         <div className="container" id="scroll-to">
           <PredictionDetails data={data} />
           <div className="prediction-bottom">
-            <div className="histogram">
+            <div className="histogram-container">
               <div id="histogram-title">
                 <span>
-                  Predicted vs. Observed Outcomes for All Data, 1987-2019 (n=2,978)
+                  Predicted vs. Observed Outcomes for All Data, 1987-2019
+                  (n=2,978)
                 </span>
               </div>
-              <img
-                src={histogram}
-                alt="Histogram for Predicted % Chance of >50 Spots"
-              />
+              <Histogram />
             </div>
             <AboutPredictions />
           </div>
@@ -119,18 +118,38 @@ const Prediction = (props) => {
       <div id="toggles-overlay">
         <div className="selection-p">
           <div
-            className={dataMode === DATA_MODES.COUNTY ? 'selected-option-p' : 'unselected-option-p'}
+            className={
+              dataMode === DATA_MODES.COUNTY
+                ? 'selected-option-p'
+                : 'unselected-option-p'
+            }
             onClick={() => setDataMode(DATA_MODES.COUNTY)}
           >
-            <p className={dataMode === DATA_MODES.COUNTY ? 'selected-option-text-p' : 'unselected-option-text-p'}>
+            <p
+              className={
+                dataMode === DATA_MODES.COUNTY
+                  ? 'selected-option-text-p'
+                  : 'unselected-option-text-p'
+              }
+            >
               Counties
             </p>
           </div>
           <div
-            className={dataMode !== DATA_MODES.COUNTY ? 'selected-option-p' : 'unselected-option-p'}
+            className={
+              dataMode !== DATA_MODES.COUNTY
+                ? 'selected-option-p'
+                : 'unselected-option-p'
+            }
             onClick={() => setDataMode(DATA_MODES.RANGER_DISTRICT)}
           >
-            <p className={dataMode !== DATA_MODES.COUNTY ? 'selected-option-text-p' : 'unselected-option-text-p'}>
+            <p
+              className={
+                dataMode !== DATA_MODES.COUNTY
+                  ? 'selected-option-text-p'
+                  : 'unselected-option-text-p'
+              }
+            >
               Federal Land
             </p>
           </div>

--- a/src/screens/prediction/component.js
+++ b/src/screens/prediction/component.js
@@ -9,21 +9,13 @@ import {
   SelectionBar,
 } from './components';
 
-import { Loading } from '../../components';
+import { Histogram, Loading } from '../../components';
 
 import { DATA_MODES } from '../../constants';
 
 import './style.scss';
 
 import closeIcon from '../../assets/icons/close.png';
-
-// import histogrambin1 from '../../assets/images/spb-histogram-bin1.png';
-// import histogrambin2 from '../../assets/images/spb-histogram-bin2.png';
-// import histogrambin3 from '../../assets/images/spb-histogram-bin3.png';
-// import histogrambin4 from '../../assets/images/spb-histogram-bin4.png';
-// import histogrambin5 from '../../assets/images/spb-histogram-bin5.png';
-// import histogrambin6 from '../../assets/images/spb-histogram-bin6.png';
-import Histogram from '../../components/histogram-components/histogram/component';
 
 const Prediction = (props) => {
   const {
@@ -40,7 +32,7 @@ const Prediction = (props) => {
     setCounty,
     rangerDistrict,
     setRangerDistrict,
-    frequencyArray,
+    frequency,
   } = props;
 
   // functions for showing modal
@@ -59,30 +51,10 @@ const Prediction = (props) => {
     clearAllSelections(); // clears selections initially when switching to this tab
   }, [clearAllSelections]);
 
-  const updateWithBorder = (array, probSpotsGT50) => {
-    const arrayUpdated = array.map((item) => {
-      const rangeArray = item.range.split('-');
-
-      if (probSpotsGT50 >= rangeArray[0] && probSpotsGT50 < rangeArray[1]) {
-        return { ...item, withBorder: true };
-      } else return item;
-    });
-
-    return arrayUpdated;
-  };
-
-  const totalFrequency = frequencyArray.reduce(
-    (sum, item) => sum + item.frequency,
-    0,
-  );
-
   const predModal = () => {
     if (!predictionModal) return null;
     const { probSpotsGT50 } = data[0];
-    const updatedFrequencyArray = updateWithBorder(
-      frequencyArray,
-      probSpotsGT50,
-    );
+
     return (
       <Modal
         isOpen={predictionModal}
@@ -103,10 +75,10 @@ const Prediction = (props) => {
               <div id="histogram-title">
                 <span>
                   {`Predicted vs. Observed Outcomes for All Data, 1987-${endYear}
-                  (n=${totalFrequency.toLocaleString()})`}
+                  (n=${frequency.toLocaleString()})`}
                 </span>
               </div>
-              <Histogram frequencyArray={updatedFrequencyArray} />
+              <Histogram probSpotsGT50={probSpotsGT50} />
             </div>
             <AboutPredictions />
           </div>

--- a/src/screens/prediction/component.js
+++ b/src/screens/prediction/component.js
@@ -28,6 +28,7 @@ import Histogram from '../../components/histogram-components/histogram/component
 const Prediction = (props) => {
   const {
     data,
+    endYear,
     fetchErrorText,
     isLoading,
     predictionModal,
@@ -39,6 +40,7 @@ const Prediction = (props) => {
     setCounty,
     rangerDistrict,
     setRangerDistrict,
+    frequencyArray,
   } = props;
 
   // functions for showing modal
@@ -57,26 +59,30 @@ const Prediction = (props) => {
     clearAllSelections(); // clears selections initially when switching to this tab
   }, [clearAllSelections]);
 
-  // const getHistogram = (probSpotsGT50) => {
-  //   if (probSpotsGT50 < 0.025) {
-  //     return histogrambin1;
-  //   } else if (probSpotsGT50 < 0.05) {
-  //     return histogrambin2;
-  //   } else if (probSpotsGT50 < 0.15) {
-  //     return histogrambin3;
-  //   } else if (probSpotsGT50 < 0.25) {
-  //     return histogrambin4;
-  //   } else if (probSpotsGT50 < 0.4) {
-  //     return histogrambin5;
-  //   } else {
-  //     return histogrambin6;
-  //   }
-  // };
+  const updateWithBorder = (array, probSpotsGT50) => {
+    const arrayUpdated = array.map((item) => {
+      const rangeArray = item.range.split('-');
+
+      if (probSpotsGT50 >= rangeArray[0] && probSpotsGT50 < rangeArray[1]) {
+        return { ...item, withBorder: true };
+      } else return item;
+    });
+
+    return arrayUpdated;
+  };
+
+  const totalFrequency = frequencyArray.reduce(
+    (sum, item) => sum + item.frequency,
+    0,
+  );
 
   const predModal = () => {
     if (!predictionModal) return null;
-    // const { probSpotsGT50 } = data[0];
-    // const histogram = getHistogram(probSpotsGT50);
+    const { probSpotsGT50 } = data[0];
+    const updatedFrequencyArray = updateWithBorder(
+      frequencyArray,
+      probSpotsGT50,
+    );
     return (
       <Modal
         isOpen={predictionModal}
@@ -96,11 +102,11 @@ const Prediction = (props) => {
             <div className="histogram-container">
               <div id="histogram-title">
                 <span>
-                  Predicted vs. Observed Outcomes for All Data, 1987-2019
-                  (n=2,978)
+                  {`Predicted vs. Observed Outcomes for All Data, 1987-${endYear}
+                  (n=${totalFrequency.toLocaleString()})`}
                 </span>
               </div>
-              <Histogram />
+              <Histogram frequencyArray={updatedFrequencyArray} />
             </div>
             <AboutPredictions />
           </div>

--- a/src/screens/prediction/components/prediction-details/component.js
+++ b/src/screens/prediction/components/prediction-details/component.js
@@ -32,13 +32,13 @@ const PredictionDetails = (props) => {
               <p id="prediction-subtitle">{data[0].year} Prediction</p>
               <div className="percentages">
                 <div className="prediction-circle">
-                  <div className={`circle ${getFillColor(data[0].probSpotsGT0).colorName}`} id="any-spots">
+                  <div className={`circle color-fill-with-shadow ${getFillColor(data[0].probSpotsGT0).colorName}`} id="any-spots">
                     <div id="percent">{((data[0].probSpotsGT0) * 100).toFixed(1)}%</div>
                     <p>Predicted % Chance of Any Spots ({'>'}0 spots)</p>
                   </div>
                 </div>
                 <div className="prediction-circle">
-                  <div className={`circle ${getFillColor(data[0].probSpotsGT50).colorName}`} id="outbreak">
+                  <div className={`circle color-fill-with-shadow ${getFillColor(data[0].probSpotsGT50).colorName}`} id="outbreak">
                     <div id="percent">{((data[0].probSpotsGT50) * 100).toFixed(1)}%</div>
                     <p>Predicted % Chance of Outbreak ({'>'}50 spots)</p>
                   </div>

--- a/src/screens/prediction/components/prediction-details/style.scss
+++ b/src/screens/prediction/components/prediction-details/style.scss
@@ -65,38 +65,6 @@
     margin-left: 40px;
     margin-right: 30px;
     margin-bottom: 100px;
-
-    &.blue {
-        background-color: $blue500;
-        box-shadow: 0 6px 20px -2px rgba($blue500, 0.55);
-    }
-    
-    &.yellow {
-        background-color: $yellow;
-        box-shadow: 0 6px 20px -2px rgba($yellow, 0.55);
-    }
-    
-    &.orange {
-        background-color: $orange;
-        box-shadow: 0 6px 20px -2px rgba($orange, 0.55);
-    }
-    
-    &.brightRed {
-        background-color: $red400;
-        box-shadow: 0 6px 20px -2px rgba($red400, 0.55);
-    }
-    
-    &.darkerRed {
-        background-color: $red600;
-        box-shadow: 0 6px 20px -2px rgba($red600, 0.55);
-        color: $white;
-    }
-    
-    &.darkRed {
-        background-color: $red900;
-        box-shadow: 0 6px 20px -2px rgba($red900, 0.55);
-        color: $white;
-    }
 }
 
 .circle p {

--- a/src/screens/prediction/index.js
+++ b/src/screens/prediction/index.js
@@ -30,61 +30,12 @@ const mapStateToProps = (state) => {
       county,
       rangerDistrict,
     },
+    histogram: {
+      frequency,
+    },
   } = state;
 
   const isLoading = fetchingPredictions;
-
-  // TODO fill with real data
-  const frequencyArray = [
-    {
-      range: '0-0.025',
-      frequency: 1234,
-      withBorder: false,
-      data: [450, 50, 0, 0, 0, 0, 0],
-    },
-    {
-      range: '0.025-0.05',
-      frequency: 1456,
-      withBorder: false,
-      data: [440, 90, 15, 15, 0, 20, 0],
-    },
-    {
-      range: '0.05-0.15',
-      frequency: 678,
-      withBorder: false,
-      data: [450, 150, 30, 30, 15, 15, 0],
-    },
-    {
-      range: '0.15-0.25',
-      frequency: 3456,
-      withBorder: false,
-      data: [450, 250, 80, 180, 100, 100, 20],
-    },
-    {
-      range: '0.25-0.4',
-      frequency: 78,
-      withBorder: false,
-      data: [450, 300, 100, 230, 150, 130, 50],
-    },
-    {
-      range: '0.4-0.6',
-      frequency: 789,
-      withBorder: false,
-      data: [220, 180, 150, 230, 220, 300, 450],
-    },
-    {
-      range: '0.6-0.8',
-      frequency: 1234,
-      withBorder: false,
-      data: [220, 180, 150, 230, 220, 300, 450],
-    },
-    {
-      range: '0.8-1',
-      frequency: 89,
-      withBorder: false,
-      data: [220, 180, 150, 230, 220, 300, 450],
-    },
-  ];
 
   return {
     data: predictions,
@@ -96,7 +47,7 @@ const mapStateToProps = (state) => {
     dataMode,
     county,
     rangerDistrict,
-    frequencyArray,
+    frequency,
   };
 };
 

--- a/src/screens/prediction/index.js
+++ b/src/screens/prediction/index.js
@@ -21,6 +21,7 @@ const mapStateToProps = (state) => {
     data: {
       predictions,
       fetchingPredictions,
+      yearData,
     },
     selections: {
       predictionModal,
@@ -33,8 +34,61 @@ const mapStateToProps = (state) => {
 
   const isLoading = fetchingPredictions;
 
+  // TODO fill with real data
+  const frequencyArray = [
+    {
+      range: '0-0.025',
+      frequency: 1234,
+      withBorder: false,
+      data: [450, 50, 0, 0, 0, 0, 0],
+    },
+    {
+      range: '0.025-0.05',
+      frequency: 1456,
+      withBorder: false,
+      data: [440, 90, 15, 15, 0, 20, 0],
+    },
+    {
+      range: '0.05-0.15',
+      frequency: 678,
+      withBorder: false,
+      data: [450, 150, 30, 30, 15, 15, 0],
+    },
+    {
+      range: '0.15-0.25',
+      frequency: 3456,
+      withBorder: false,
+      data: [450, 250, 80, 180, 100, 100, 20],
+    },
+    {
+      range: '0.25-0.4',
+      frequency: 78,
+      withBorder: false,
+      data: [450, 300, 100, 230, 150, 130, 50],
+    },
+    {
+      range: '0.4-0.6',
+      frequency: 789,
+      withBorder: false,
+      data: [220, 180, 150, 230, 220, 300, 450],
+    },
+    {
+      range: '0.6-0.8',
+      frequency: 1234,
+      withBorder: false,
+      data: [220, 180, 150, 230, 220, 300, 450],
+    },
+    {
+      range: '0.8-1',
+      frequency: 89,
+      withBorder: false,
+      data: [220, 180, 150, 230, 220, 300, 450],
+    },
+  ];
+
   return {
     data: predictions,
+    endYear: yearData[yearData.length - 1]?.year,
     fetchErrorText,
     isLoading,
     predictionModal,
@@ -42,6 +96,7 @@ const mapStateToProps = (state) => {
     dataMode,
     county,
     rangerDistrict,
+    frequencyArray,
   };
 };
 

--- a/src/screens/prediction/style.scss
+++ b/src/screens/prediction/style.scss
@@ -9,8 +9,6 @@
 }
 
 .prediction-bottom {
-    display: flex;
-    flex-direction: row;
     margin-top: 25px;
 }
 
@@ -94,7 +92,7 @@
     }
 }
 
-.histogram {
+.histogram-container {
     padding: 25px;
     border-radius: 26px;
     box-shadow: 0 35px 90px -10px rgba(0, 0, 0, 0.06);
@@ -102,16 +100,17 @@
     height: 0%;
 }
 
-.histogram #histogram-title {
+.histogram-container #histogram-title {
     font-size: 24px;
     font-weight: 600;
     line-height: 1.6;
     letter-spacing: normal;
     text-align: left;
     color: $greyBlue900;
+    margin-bottom: 40px;
 }
 
-.histogram img {
+.histogram-container img {
     width: 45vw;
 }
 
@@ -125,7 +124,7 @@
     width: 70vw;
     padding: 50px;
     border-radius: 20px;
-    background-color: $white;
+    background-color: $backgroundColor;
     // TODO: replace box shadow with grayer background later
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3); 
     overflow-y: scroll;

--- a/src/screens/prediction/style.scss
+++ b/src/screens/prediction/style.scss
@@ -129,6 +129,11 @@
     // TODO: replace box shadow with grayer background later
     box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3); 
     overflow-y: scroll;
+
+    #close-icon {
+        position: sticky;
+        top: -25px;
+    }
 }
 
 // remove unnecessary blue outline from modal (does not impact accessibility)

--- a/src/screens/prediction/style.scss
+++ b/src/screens/prediction/style.scss
@@ -94,6 +94,7 @@
 
 .histogram-container {
     padding: 25px;
+    padding-right: 75px;
     border-radius: 26px;
     box-shadow: 0 35px 90px -10px rgba(0, 0, 0, 0.06);
     background-color: $white;

--- a/src/screens/trapping-data/components/trapping-data-map/component.js
+++ b/src/screens/trapping-data/components/trapping-data-map/component.js
@@ -187,9 +187,6 @@ const HistoricalMap = (props) => {
 
     createdMap.addControl(new mapboxgl.NavigationControl());
 
-    // disable map zoom when using scroll
-    createdMap.scrollZoom.disable();
-
     const legendTagsToSet = thresholds.map((threshold, index) => {
       const color = colors[index];
 

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -13,6 +13,7 @@ const SUBROUTES = {
   SPOT_DATA_COUNTY: 'summarized-county/spots/upload',
   SPOT_DATA_RD: 'summarized-rangerdistrict/spots/upload',
   SURVEY123: 'survey123/upload',
+  HISTOGRAM: 'histogram',
 };
 
 /**
@@ -157,4 +158,27 @@ export const updatePassword = async (email, currentPassword, password) => {
  */
 export const sendForgotPasswordEmail = async (email) => {
   return userService.sendForgotPasswordEmail(email);
+};
+
+/**
+ * @description update the histogram data with new trapping data
+ * @returns {Promise<Object>} API response
+ */
+export const updateHistogram = async () => {
+  const url = `${global.API_URL}/${SUBROUTES.HISTOGRAM}/update`;
+  const token = getAuthTokenFromStorage();
+
+  try {
+    const { data: response } = await axios.post(url, {}, {
+      headers: {
+        authorization: `Bearer ${token}`,
+      },
+    });
+
+    const { data } = response;
+
+    return data;
+  } catch (error) {
+    console.error(error); throw error;
+  }
 };

--- a/src/services/histogram.js
+++ b/src/services/histogram.js
@@ -1,0 +1,19 @@
+import axios from 'axios';
+
+const SUBROUTE = 'histogram';
+
+const getHistogram = async () => {
+  const url = `${global.API_URL}/${SUBROUTE}/`;
+
+  try {
+    const { data: response } = await axios.get(url);
+
+    const { data } = response;
+
+    return { frequencyArray: data.frequencyArray, frequency: data.frequency };
+  } catch (error) {
+    console.error(error); throw error;
+  }
+};
+
+export default getHistogram;

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,11 +1,13 @@
 import * as admin from './admin';
 import * as api from './api';
 import * as blog from './blog';
+import getHistogram from './histogram';
 import * as user from './user';
 
 export {
   admin,
   api,
   blog,
+  getHistogram,
   user,
 };

--- a/src/state/actions/histogram.js
+++ b/src/state/actions/histogram.js
@@ -1,0 +1,22 @@
+import { getHistogram as getHistogramService } from '../../services';
+
+export const ActionTypes = {
+  GET_HISTOGRAM: 'GET_HISTOGRAM',
+  HISTOGRAM_API_ERROR: 'HISTOGRAM_API_ERROR',
+};
+
+export const getHistogram = () => {
+  return async (dispatch) => {
+    try {
+      const data = await getHistogramService();
+      dispatch({ type: ActionTypes.GET_HISTOGRAM, payload: data });
+    } catch (error) {
+      console.log('error', error);
+      dispatch({
+        type: ActionTypes.HISTOGRAM_API_ERROR,
+        payload: 'GET HISTOGRAM DATA',
+        error,
+      });
+    }
+  };
+};

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -44,11 +44,17 @@ import {
   deleteBlogPost,
 } from './blog';
 
+import {
+  ActionTypes as histogramActionTypes,
+  getHistogram,
+} from './histogram';
+
 const ActionTypes = {
   ...dataActionTypes,
   ...selectionActionTypes,
   ...userActionTypes,
   ...blogActionTypes,
+  ...histogramActionTypes,
 };
 
 export {
@@ -67,6 +73,7 @@ export {
   getAvailableStates,
   getAvailableSublocations,
   getAvailableYears,
+  getHistogram,
   getSparseData,
   getPredictions,
   getUserFromStorage,

--- a/src/state/reducers/histogram.js
+++ b/src/state/reducers/histogram.js
@@ -1,0 +1,22 @@
+import { ActionTypes } from '../actions';
+
+const initialState = {
+  histogramData: [],
+  frequency: '',
+  error: null,
+};
+
+const HistogramReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case ActionTypes.GET_HISTOGRAM: {
+      const { frequency, frequencyArray } = action.payload;
+      return { ...state, histogramData: frequencyArray, frequency };
+    }
+    case ActionTypes.HISTOGRAM_API_ERROR:
+      return { ...state, error: { message: action.payload.error, action: action.payload.action } };
+    default:
+      return state;
+  }
+};
+
+export default HistogramReducer;

--- a/src/state/reducers/index.js
+++ b/src/state/reducers/index.js
@@ -5,11 +5,13 @@ import ErrorReducer from './error';
 import DataReducer from './data';
 import SelectionsReducer from './selections';
 import UserReducer from './user';
+import HistogramReducer from './histogram';
 
 const rootReducer = combineReducers({
   blog: BlogReducer,
   data: DataReducer,
   error: ErrorReducer,
+  histogram: HistogramReducer,
   selections: SelectionsReducer,
   user: UserReducer,
 });

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -145,3 +145,37 @@ textarea {
 .animated-button:hover {
     opacity: 1;
 }
+
+.color-fill-with-shadow {
+    &.blue {
+        background-color: $blue500;
+        box-shadow: 0 6px 20px -2px rgba($blue500, 0.55);
+    }
+    
+    &.yellow {
+        background-color: $yellow;
+        box-shadow: 0 6px 20px -2px rgba($yellow, 0.55);
+    }
+    
+    &.orange {
+        background-color: $orange;
+        box-shadow: 0 6px 20px -2px rgba($orange, 0.55);
+    }
+    
+    &.brightRed {
+        background-color: $red400;
+        box-shadow: 0 6px 20px -2px rgba($red400, 0.55);
+    }
+    
+    &.darkerRed {
+        background-color: $red600;
+        box-shadow: 0 6px 20px -2px rgba($red600, 0.55);
+        color: $white;
+    }
+    
+    &.darkRed {
+        background-color: $red900;
+        box-shadow: 0 6px 20px -2px rgba($red900, 0.55);
+        color: $white;
+    }
+}


### PR DESCRIPTION
# Description

Change probability histogram shown in the predictions modal from static image to dynamically generated chart, which updates once a year. 
What was done:

- add echarts and implement it in the project
- connect to `pine-beetle-backend` API
- add the button which triggers chart recalculation to the admin panel
- make close icon in the prediction modal sticky
- color-code the outcomes of play with the model feature on the home page

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

## Screenshots

![Screenshot 2025-02-03 at 15 09 57](https://github.com/user-attachments/assets/31b5b391-2116-4470-b354-e2d46667fd60)
![Screenshot 2025-02-03 at 15 10 21](https://github.com/user-attachments/assets/2ffdc7b8-98e1-4117-8674-56c4106c60a4)

