### PR TITLE
feat: prepare frontend to use new R model 2025

### DIFF
--- a/src/screens/home/components/play-with-model/component.js
+++ b/src/screens/home/components/play-with-model/component.js
@@ -9,7 +9,7 @@ import {
 
 import { DATA_MODES } from '../../../../constants';
 
-export const DEFAULT_MODEL_VERSION = 2024;
+export const DEFAULT_MODEL_VERSION = 2025;
 
 const PlayWithModel = (props) => {
   const {

--- a/src/screens/home/components/play-with-model/components/play-with-model-inputs/component.js
+++ b/src/screens/home/components/play-with-model/components/play-with-model-inputs/component.js
@@ -74,6 +74,7 @@ const PlayWithModelInputs = (props) => {
   const MODEL_VERSION_INPUTS = {
     2018: ['SPOTST2', 'SPOTST1', 'CLERIDST1', 'SPB', 'ENDOBREV'],
     2024: ['SPOTST1', 'SPB', 'ENDOBREV'],
+    2025: ['SPOTST2', 'SPOTST1', 'SPB', 'ENDOBREV'],
   };
 
   const filterModelVersionInputs = (modelVersion) => {
@@ -177,7 +178,7 @@ const PlayWithModelInputs = (props) => {
           <span>Pick model version</span>
           <ChoiceInput
             id="modelVersion"
-            options={[2018, 2024]}
+            options={[2018, 2024, 2025]}
             value={modelInputs.modelVersion}
             setValue={createValueSetter('modelVersion')}
             firstOptionText="Year"

--- a/src/screens/prediction/components/prediction-details/component.js
+++ b/src/screens/prediction/components/prediction-details/component.js
@@ -10,7 +10,6 @@ import cleridIcon from '../../../../assets/icons/clerids.png';
 import { getFillColor } from '../../../../utils';
 
 const spbText = 'SPB per two weeks, averaged across traps';
-const cleridText = 'clerids per two weeks, averaged across traps';
 
 const PredictionDetails = (props) => {
   const {
@@ -70,18 +69,6 @@ const PredictionDetails = (props) => {
                     <hr />
                     <div className="year-title">{currYear - 1}</div>
                   </div>
-                  <div className="yeart1-clerids" id="clerids">
-                    <hr />
-                    <div className="content-container">
-                      <img
-                        src={cleridIcon}
-                        alt="clerids"
-                      />
-                      {/* note: model uses 77 for cleridst1 if it is null */}
-                      <div className="content-text" data-tip={cleridText}>{Math.round(data[0].cleridst1) || 'null'} <u>clerids</u></div>
-                      <ReactTooltip multiline place="right" />
-                    </div>
-                  </div>
                   <div className="yeart1-spots" id="spots">
                     <hr />
                     <div className="content-container">
@@ -108,7 +95,7 @@ const PredictionDetails = (props) => {
                     </div>
                   </div>
                   <div className="curr-endobrev" id="endobrev">
-                    <hr />
+                    <hr className="content-horizontal-rule" />
                     <div className="content-container">
                       <div className="content-text">{(data[0].endobrev === 0) ? 'no' : 'yes'} <u>endo-brevicomin</u></div>
                     </div>

--- a/src/screens/prediction/components/prediction-details/style.scss
+++ b/src/screens/prediction/components/prediction-details/style.scss
@@ -130,11 +130,20 @@
 
 .prediction-grid {
     display: grid;
-    grid-template-columns: auto 150px auto;
+    grid-template-columns: auto 200px;
     grid-template-areas: 
-    'yeart2 yeart2 yeart2-spots'
-    'yeart1 yeart1-clerids yeart1-spots'
-    'curr-year curr-spb curr-endobrev';
+    'yeart2 yeart2-spots'
+    'yeart1 yeart1-spots'
+    'curr-year curr-spb'
+    '. curr-endobrev';
+
+    @media (min-width: 1400px) {
+        grid-template-columns: auto 150px auto;
+        grid-template-areas: 
+        'yeart2 . yeart2-spots'
+        'yeart1 yeart1 yeart1-spots'
+        'curr-year curr-spb curr-endobrev';
+    } 
 }
 
 .prediction-grid > div {
@@ -183,6 +192,22 @@
 
 .curr-endobrev {
     grid-area: curr-endobrev;
+
+    .content-horizontal-rule {
+        display: none; 
+
+        @media (min-width: 1400px) {
+            display: block
+        }
+    }
+
+    .content-container {
+        margin-top: 0;
+
+        @media (min-width: 1400px) {
+            margin-top: 12px;
+        }
+    }
 }
 
 .content-container {


### PR DESCRIPTION
# Description

- add new model version to `Play with the model` functionality
- remove clerids from `Model Input Variables` section in predictions modal
- adjust styling of the above for part of the smaller screens (the smallest available in the app is still not handled)

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

## Screenshots

Please attach any design screenshots if UI update.
<img width="1042" alt="Screenshot 2025-02-11 at 15 06 05" src="https://github.com/user-attachments/assets/ebe87504-6d89-4019-b4c2-1ff036fd0462" />
<img width="1262" alt="Screenshot 2025-02-11 at 15 06 16" src="https://github.com/user-attachments/assets/b2336c5d-bb47-4580-9046-2ae35a93467a" />
