### PR TITLE
Feat/change back outbreak definition

### DIFF
--- a/src/components/histogram-components/histogram/component.js
+++ b/src/components/histogram-components/histogram/component.js
@@ -4,11 +4,11 @@ import Loader from '../../loader';
 
 import './style.scss';
 
-const updateWithBorder = (array, probSpotsGT20) => {
+const updateWithBorder = (array, probSpotsGT50) => {
   const arrayUpdated = array.map((item) => {
     const rangeArray = item.range.split('-');
 
-    if (probSpotsGT20 >= rangeArray[0] && probSpotsGT20 < rangeArray[1]) {
+    if (probSpotsGT50 >= rangeArray[0] && probSpotsGT50 < rangeArray[1]) {
       return { ...item, withBorder: true };
     } else return item;
   });
@@ -16,10 +16,10 @@ const updateWithBorder = (array, probSpotsGT20) => {
   return arrayUpdated;
 };
 
-const Histogram = ({ histogramData, getHistogram, probSpotsGT20 }) => {
+const Histogram = ({ histogramData, getHistogram, probSpotsGT50 }) => {
   useEffect(() => getHistogram(), [getHistogram]);
 
-  const updatedHistogramData = updateWithBorder(histogramData, probSpotsGT20);
+  const updatedHistogramData = updateWithBorder(histogramData, probSpotsGT50);
 
   const getXAxisLegend = () => {
     if (updatedHistogramData) {
@@ -48,9 +48,9 @@ const Histogram = ({ histogramData, getHistogram, probSpotsGT20 }) => {
             <p>{'> 249'}</p>
             <p>100 - 249</p>
             <p>50 - 99</p>
-            <p>20 - 49</p>
           </div>
           <div className="histogram__legend histogram__legend--blue">
+            <p>20 - 49</p>
             <p>10 - 19</p>
             <p>1 - 9</p>
             <p>0</p>
@@ -75,7 +75,7 @@ const Histogram = ({ histogramData, getHistogram, probSpotsGT20 }) => {
             ))}
           </div>
           <h4 className="histogram__x-axis-title">
-            {'Predicted % chance of > 20 spots'}
+            {'Predicted % chance of > 50 spots'}
           </h4>
         </div>
       </div>

--- a/src/components/histogram-components/single-chart/component.js
+++ b/src/components/histogram-components/single-chart/component.js
@@ -66,8 +66,8 @@ const SingleChart = ({
         barCategoryGap: '1%',
         itemStyle: {
           color: (params) => {
-            const categoriesAbove20 = ['>249', '100-249', '50-99', '20-49'];
-            return categoriesAbove20.includes(params.name)
+            const categoriesAbove50 = ['>249', '100-249', '50-99'];
+            return categoriesAbove50.includes(params.name)
               ? '#FFC148'
               : '#86CCFF';
           },

--- a/src/screens/home/components/play-with-model/components/play-with-model-outputs/component.js
+++ b/src/screens/home/components/play-with-model/components/play-with-model-outputs/component.js
@@ -17,7 +17,7 @@ const PlayWithModelOutputs = (props) => {
   } = props;
 
   const probSpots = customPrediction.probSpotsGT0;
-  const probOutbreak = customPrediction.probSpotsGT20;
+  const probOutbreak = customPrediction.probSpotsGT50;
 
   const validCustomPredictions = !isError && !isLoading && !Number.isNaN(probSpots) && !Number.isNaN(probOutbreak);
 
@@ -58,7 +58,7 @@ const PlayWithModelOutputs = (props) => {
             : '--'}
         </div>
         <div id="prob-text">
-          <p>Predicted % Chance of Outbreak ({'>'}20 spots)</p>
+          <p>Predicted % Chance of Outbreak ({'>'}50 spots)</p>
         </div>
       </div>
     </>

--- a/src/screens/prediction/component.js
+++ b/src/screens/prediction/component.js
@@ -49,7 +49,7 @@ const Prediction = (props) => {
 
   const predModal = () => {
     if (!predictionModal) return null;
-    const { probSpotsGT20 } = data[0];
+    const { probSpotsGT50 } = data[0];
 
     return (
       <Modal
@@ -74,7 +74,7 @@ const Prediction = (props) => {
                   (n=${frequency.toLocaleString()})`}
                 </span>
               </div>
-              <Histogram probSpotsGT20={probSpotsGT20} />
+              <Histogram probSpotsGT50={probSpotsGT50} />
             </div>
             <AboutPredictions />
           </div>

--- a/src/screens/prediction/components/about-predictions/component.js
+++ b/src/screens/prediction/components/about-predictions/component.js
@@ -7,7 +7,7 @@ const AboutPredictions = () => {
       <div className="about-title">About Predictions</div>
       <ul>
         <li>The predictive model gives the probability for various levels of southern pine beetle spot severity.</li>
-        <li>We describe the probability of an outbreak as the probability of more than 20 spots, though various forest professionals may use other benchmarks.</li>
+        <li>We describe the probability of an outbreak as the probability of more than 50 spots, though various forest professionals may use other benchmarks.</li>
         <li>Please note that the model is probabilistic. An outcome with a low probability may nevertheless occur. </li>
       </ul>
     </div>

--- a/src/screens/prediction/components/overview-text/component.js
+++ b/src/screens/prediction/components/overview-text/component.js
@@ -5,7 +5,7 @@ import './style.scss';
 import questionIcon from '../../../../assets/icons/help-circle.png';
 
 const helpText = `This tool uses annual trapping data and the most recent two years of 
-spot data to predict the likelihood of an outbreak (greater than 20 spots per location) in the coming summer. 
+spot data to predict the likelihood of an outbreak (greater than 50 spots per location) in the coming summer. 
 Resource managers enter their trapping data from approximately March-June of each season. Each location traps 
 over 4-6 weeks, and enters their data when complete. When complete data is entered, a prediction for that 
 location becomes available on this page. Observed outcome data is usually uploaded in January following a 

--- a/src/screens/prediction/components/prediction-details/component.js
+++ b/src/screens/prediction/components/prediction-details/component.js
@@ -37,9 +37,9 @@ const PredictionDetails = (props) => {
                   </div>
                 </div>
                 <div className="prediction-circle">
-                  <div className={`circle color-fill-with-shadow ${getFillColor(data[0].probSpotsGT20).colorName}`} id="outbreak">
-                    <div id="percent">{((data[0].probSpotsGT20) * 100).toFixed(1)}%</div>
-                    <p>Predicted % Chance of Outbreak ({'>'}20 spots)</p>
+                  <div className={`circle color-fill-with-shadow ${getFillColor(data[0].probSpotsGT50).colorName}`} id="outbreak">
+                    <div id="percent">{((data[0].probSpotsGT50) * 100).toFixed(1)}%</div>
+                    <p>Predicted % Chance of Outbreak ({'>'}50 spots)</p>
                   </div>
                 </div>
               </div>

--- a/src/screens/prediction/components/prediction-map/component.js
+++ b/src/screens/prediction/components/prediction-map/component.js
@@ -91,7 +91,7 @@ const PredictionMap = (props) => {
         const {
           county: countyName,
           probSpotsGT0: probAny,
-          probSpotsGT20: probOutbreak,
+          probSpotsGT50: probOutbreak,
         } = pred;
 
         setPredictionHover((
@@ -129,7 +129,7 @@ const PredictionMap = (props) => {
 
     predictions.forEach(({
       county,
-      probSpotsGT20: fillProb,
+      probSpotsGT50: fillProb,
       rangerDistrict,
       state,
     }) => {
@@ -310,7 +310,7 @@ const PredictionMap = (props) => {
           hover={predictionHover}
           legend={(
             <>
-              <div className="legend-key-title">Probability of &gt;20 spots</div>
+              <div className="legend-key-title">Probability of &gt;50 spots</div>
               {legendTags}
             </>
         )}

--- a/src/screens/results-comparison/components/comparison-map/component.js
+++ b/src/screens/results-comparison/components/comparison-map/component.js
@@ -21,13 +21,13 @@ import './style.scss';
 import { isInvalidNumber } from '../../../../utils/map';
 
 const getFillColor = (fillProb, sumSpots) => {
-  if (fillProb >= 0.2 && sumSpots > 20) {
+  if (fillProb >= 0.2 && sumSpots > 50) {
     return colors[0];
-  } else if (fillProb < 0.2 && sumSpots < 20) {
+  } else if (fillProb < 0.2 && sumSpots < 50) {
     return colors[1];
-  } else if (fillProb < 0.2 && sumSpots > 20) {
+  } else if (fillProb < 0.2 && sumSpots > 50) {
     return colors[2];
-  } else if (fillProb >= 0.2 && sumSpots <= 20) {
+  } else if (fillProb >= 0.2 && sumSpots <= 50) {
     return colors[3];
   } else {
     return colors[4];
@@ -78,7 +78,7 @@ const ComparisonMap = (props) => {
       if (pred && x && y) {
         const {
           county: countyName,
-          probSpotsGT20: probOutbreak,
+          probSpotsGT50: probOutbreak,
           sumSpots: spotsCount,
         } = pred;
 
@@ -117,7 +117,7 @@ const ComparisonMap = (props) => {
 
     comparisonData.forEach(({
       county,
-      probSpotsGT20: fillProb,
+      probSpotsGT50: fillProb,
       sumSpots,
       rangerDistrict,
       state,

--- a/src/screens/trapping-data/component.js
+++ b/src/screens/trapping-data/component.js
@@ -27,15 +27,22 @@ const TrappingData = (props) => {
     setChartMode,
     setDataMode,
     clearAllSelections,
+    setStartYear,
+    availableYears,
   } = props;
 
   const isGraphView = chartMode === CHART_MODES.GRAPH;
-  const setGraphView = () => setChartMode(CHART_MODES.GRAPH);
   const setMapView = () => setChartMode(CHART_MODES.MAP);
 
   useEffect(() => {
     clearAllSelections(); // clears selections initially when switching to this tab
   }, [clearAllSelections]);
+
+  // TODO handle other way here as well
+  const handleChangeToGraphView = () => {
+    setChartMode(CHART_MODES.GRAPH);
+    setStartYear(availableYears[0]);
+  };
 
   return (
     <div>
@@ -66,7 +73,7 @@ const TrappingData = (props) => {
           <div className="selection">
             <div
               className={isGraphView ? 'selected-option-2' : 'unselected-option'}
-              onClick={setGraphView}
+              onClick={handleChangeToGraphView}
             >
               <img
                 src={isGraphView ? graphSelectedIcon : graphUnselectedIcon}

--- a/src/screens/trapping-data/components/line-chart/components/spb-chart/component.js
+++ b/src/screens/trapping-data/components/line-chart/components/spb-chart/component.js
@@ -118,8 +118,6 @@ const SPBChart = (props) => {
       [year]: avgSpbPerTrapPer2Weeks,
     }), getYearRange(startYear, endYear).reduce((p, c) => ({ ...p, [c]: null }), {}));
 
-    console.log('filtered', yearData.filter(({ isValidForPrediction }) => isValidForPrediction === 0));
-
     // update chartData
     updatedSPBChartData.datasets[0].data = Object.values(spbMap);
 

--- a/src/screens/trapping-data/components/line-chart/components/spb-chart/component.js
+++ b/src/screens/trapping-data/components/line-chart/components/spb-chart/component.js
@@ -79,7 +79,7 @@ const SPBChart = (props) => {
           const { label } = d.datasets[tooltipItem.datasetIndex];
           const value = tooltipItem.yLabel;
 
-          return `${label}: ${value.toFixed(2)}`;
+          return `${label}: ${value}`;
         },
       },
     },
@@ -111,10 +111,14 @@ const SPBChart = (props) => {
     updatedSPBChartData.labels = getYearRange(startYear, endYear);
 
     // get sum of spb by year
-    const spbMap = yearData.reduce((acc, { year, sumSpbPer2Weeks }) => ({
+    const spbMap = yearData.reduce((acc, {
+      year, avgSpbPerTrapPer2Weeks,
+    }) => ({
       ...acc,
-      [year]: sumSpbPer2Weeks,
+      [year]: avgSpbPerTrapPer2Weeks,
     }), getYearRange(startYear, endYear).reduce((p, c) => ({ ...p, [c]: null }), {}));
+
+    console.log('filtered', yearData.filter(({ isValidForPrediction }) => isValidForPrediction === 0));
 
     // update chartData
     updatedSPBChartData.datasets[0].data = Object.values(spbMap);

--- a/src/screens/trapping-data/components/line-chart/style.scss
+++ b/src/screens/trapping-data/components/line-chart/style.scss
@@ -4,7 +4,7 @@
     box-shadow: 0 35px 90px -10px rgba(0, 0, 0, 0.06);
     background-color: $white;
     margin-bottom: 100px;
-    margin-top: 30px;
+    padding-top: 70px;
 }
 
 #chart-title {

--- a/src/screens/trapping-data/components/selection-bar/style.scss
+++ b/src/screens/trapping-data/components/selection-bar/style.scss
@@ -13,6 +13,7 @@
     justify-content: space-evenly;
     align-items: center;
     padding: 20px;
+    margin-bottom: 30px;
 
     .historicalbar-year-selection {
         display: flex;

--- a/src/screens/trapping-data/index.js
+++ b/src/screens/trapping-data/index.js
@@ -1,6 +1,8 @@
 import { connect } from 'react-redux';
 
-import { setChartMode, setDataMode, clearSelections } from '../../state/actions';
+import {
+  setChartMode, setDataMode, clearSelections, setStartYear,
+} from '../../state/actions';
 
 import TrappingData from './component';
 
@@ -14,6 +16,9 @@ const mapStateToProps = (state) => {
     selections: {
       chartMode,
       dataMode,
+      startYear,
+      endYear,
+      availableHistoricalYears,
     },
     data: {
       fetchingAggregateYearData,
@@ -29,6 +34,9 @@ const mapStateToProps = (state) => {
     dataMode,
     isLoading,
     errorText,
+    startYear,
+    endYear,
+    availableYears: availableHistoricalYears,
   };
 };
 
@@ -42,6 +50,9 @@ const mapDispatchToProps = (dispatch) => {
     },
     setDataMode: (dataMode) => {
       dispatch(setDataMode(dataMode));
+    },
+    setStartYear: (year) => {
+      dispatch(setStartYear(year));
     },
   };
 };


### PR DESCRIPTION
# Description

Changes outbreak definition back from more than 20 spots to more than 50 spots.
Fixes a bug happening when user was switching from map view to graph view - the year range was set to `currentYear` - `currentYear`.
Uses `avgSpbPerTrapPer2Weeks` in SPB graph

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

## Screenshots

Please attach any design screenshots if UI update.
