### PR TITLE
fix: fix blog post showing the date a month earlier

### DIFF
--- a/src/utils/blog.js
+++ b/src/utils/blog.js
@@ -19,7 +19,7 @@ const getLatestBlogPost = (blogPosts) => {
 // Return string with US date format
 const getDateToDisplay = (dateToParse) => {
   const date = new Date(dateToParse);
-  return `${date.getMonth()}/${date.getDate()}/${date.getFullYear()}`;
+  return `${date.getMonth() + 1}/${date.getDate()}/${date.getFullYear()}`;
 };
 
 // Return string with blog post creation and editing dates


### PR DESCRIPTION
# Description

fix blog post showing the date a month earlier (Date.getMonth() is zero-based)

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

## Screenshots

Please attach any design screenshots if UI update.
