### PR TITLE
feat: adjust scroll hint placement

### DIFF
--- a/src/components/scroll-hint/style.scss
+++ b/src/components/scroll-hint/style.scss
@@ -1,13 +1,19 @@
 .scroll-hint {
   position: fixed;
+  display: flex;
+  justify-content: center;
   bottom: 30px;
-  right: 30px;
+  left: 50%;
   transform: translateX(-50%);
-  font-size: 1.5rem;
-  opacity: 0.5;
+  font-size: 2.5rem;
+  opacity: 0.8;
   pointer-events: none;
   animation: bounce 2s infinite;
   z-index: 1000;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 100%;
+  background-color: $white;
 }
 
 @keyframes bounce {

--- a/src/screens/prediction/components/overview-text/component.js
+++ b/src/screens/prediction/components/overview-text/component.js
@@ -29,7 +29,7 @@ const OverviewText = (_props) => (
       <ReactTooltip className="overview-text-tooltip" multiline place="right" />
     </div>
     <div>
-      <p>
+      <p className="explanatory-text">
         {explanatoryText}
       </p>
     </div>

--- a/src/screens/results-comparison/component.js
+++ b/src/screens/results-comparison/component.js
@@ -4,6 +4,8 @@ import {
 } from './components';
 import { Loading, ScrollHint } from '../../components';
 
+import './style.scss';
+
 const ResultsComparison = (props) => {
   const { isLoading } = props;
   return (

--- a/src/screens/results-comparison/components/overview-text/component.js
+++ b/src/screens/results-comparison/components/overview-text/component.js
@@ -19,7 +19,7 @@ const OverviewText = (_props) => (
       </h1>
     </div>
     <div>
-      <p>
+      <p className="explanatory-text">
         {explanatoryText}
       </p>
     </div>

--- a/src/screens/results-comparison/components/overview-text/style.scss
+++ b/src/screens/results-comparison/components/overview-text/style.scss
@@ -1,0 +1,3 @@
+.explanatory-text {
+  text-align: left;
+}

--- a/src/screens/results-comparison/style.scss
+++ b/src/screens/results-comparison/style.scss
@@ -1,0 +1,3 @@
+.prediction-chart-text {
+  text-align: left;
+}

--- a/src/screens/trapping-data/components/overview-text/component.js
+++ b/src/screens/trapping-data/components/overview-text/component.js
@@ -27,7 +27,7 @@ const OverviewText = (_props) => (
       />
       <ReactTooltip multiline place="right" />
     </div>
-    <div>
+    <div className="explanatory-text">
       <ReactReadMoreReadLess
         charLimit={250}
         readMoreText="Read more"


### PR DESCRIPTION
# Description

Adjust placement of a scroll hint component to be centered. Change explanatory texts alignment to left.

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

## Screenshots

Please attach any design screenshots if UI update.
