### PR TITLE
Improve Observed Outcomes initial load by parallelizing data fetches and caching scatter chart data

### DIFF
--- a/src/screens/observed-outcomes/components/scatter-chart/component.js
+++ b/src/screens/observed-outcomes/components/scatter-chart/component.js
@@ -20,13 +20,8 @@ const getCustomRegressionLine = () => {
 };
 
 const ScatterChart = ({
-  data, predictionYear, getChartData, dataMode, selectedState, county, rangerDistrict,
+  data, isLoading, predictionYear, dataMode, selectedState, county, rangerDistrict,
 }) => {
-  // Fetch data on mount and when filters change
-  useEffect(() => {
-    getChartData();
-  }, [dataMode, selectedState, county, rangerDistrict, getChartData]);
-
   const chartRef = useRef(null);
 
   const formattedData = useMemo(() => {

--- a/src/screens/observed-outcomes/components/scatter-chart/index.js
+++ b/src/screens/observed-outcomes/components/scatter-chart/index.js
@@ -1,12 +1,11 @@
 import { connect } from 'react-redux';
-
-import { getScatterChartData } from '../../../../state/actions';
 import ScatterChart from './component';
 
 const mapStateToProps = (state) => {
   const {
     data: {
       scatterChart,
+      fetchingScatterChartData,
     },
     selections: {
       predictionYear,
@@ -19,6 +18,7 @@ const mapStateToProps = (state) => {
 
   return {
     data: scatterChart,
+    isLoading: fetchingScatterChartData,
     predictionYear,
     dataMode,
     selectedState,
@@ -27,15 +27,7 @@ const mapStateToProps = (state) => {
   };
 };
 
-const mapDispatchToProps = (dispatch) => {
-  return {
-    getChartData: () => {
-      dispatch(getScatterChartData());
-    },
-  };
-};
-
 export default connect(
   mapStateToProps,
-  mapDispatchToProps
+  null
 )(ScatterChart);

--- a/src/screens/observed-outcomes/index.js
+++ b/src/screens/observed-outcomes/index.js
@@ -1,16 +1,15 @@
 import { connect } from 'react-redux';
 import ObservedOutcomes from './component';
-import {
-  getAvailableYears,
-  getObservedOutcomesData,
-  getScatterChartData,
-} from '../../state/actions';
+import { getAvailableYears } from '../../state/actions';
+import { fetchAllObservedOutcomesData } from '../../state/actions/data';
 
 const mapStateToProps = (state) => {
   const {
     data: {
       fetchingResultsComparisonData,
-      resultsComparisonData,
+      fetchingScatterChartData,
+      resultsComparison,
+      scatterChart,
     },
     selections: {
       predictionYear,
@@ -19,8 +18,11 @@ const mapStateToProps = (state) => {
   } = state;
 
   return {
-    isLoading: fetchingResultsComparisonData,
-    hasData: resultsComparisonData && resultsComparisonData.length > 0,
+    // loading while either dataset is being fetched
+    isLoading: fetchingResultsComparisonData || fetchingScatterChartData,
+    // consider page "has data" only when both datasets are present
+    hasData: (resultsComparison && resultsComparison.length > 0)
+      && (scatterChart && scatterChart.length > 0),
     predictionYear,
     yearsLoaded: availablePredictionYears && availablePredictionYears.length > 0,
   };
@@ -29,8 +31,7 @@ const mapStateToProps = (state) => {
 const mapDispatchToProps = (dispatch) => ({
   fetchAvailableYears: () => dispatch(getAvailableYears()),
   fetchData: (year) => {
-    dispatch(getObservedOutcomesData(year));
-    dispatch(getScatterChartData());
+    dispatch(fetchAllObservedOutcomesData(year));
   },
 });
 

--- a/src/state/actions/data.js
+++ b/src/state/actions/data.js
@@ -404,3 +404,119 @@ export const getScatterChartData = () => {
     }
   };
 };
+
+/**
+ * @description fetches both observed outcomes comparison data and scatter chart data in parallel
+ *              and avoids duplicate in-flight requests / unnecessary refetches
+ */
+export const fetchAllObservedOutcomesData = (year) => {
+  return async (dispatch, getState) => {
+    if (!year) {
+      return;
+    }
+
+    const state = getState();
+    const {
+      data: {
+        fetchingResultsComparisonData,
+        fetchingScatterChartData,
+        resultsComparison,
+        scatterChart,
+      },
+      selections: {
+        county,
+        dataMode,
+        rangerDistrict,
+        state: selectedState,
+      },
+    } = state;
+
+    // Skip if a fetch is already in progress
+    if (fetchingResultsComparisonData || fetchingScatterChartData) {
+      return;
+    }
+
+    // Skip if we already have both datasets cached
+    const hasMapData = resultsComparison && resultsComparison.length > 0;
+    const hasChartData = scatterChart && scatterChart.length > 0;
+    if (hasMapData && hasChartData) {
+      return;
+    }
+
+    const filters = {
+      state: selectedState,
+      county,
+      rangerDistrict,
+      year,
+    };
+
+    dispatch({ type: ActionTypes.FETCHING_OBSERVED_OUTCOMES_DATA, payload: true });
+    dispatch({ type: ActionTypes.FETCHING_SCATTER_CHART_DATA, payload: true });
+
+    try {
+      // Try cache first for scatter chart (1h TTL)
+      const cacheKey = `scatterChart_${dataMode}`;
+      const cachedData = localStorage.getItem(cacheKey);
+      let scatterPromise;
+      if (cachedData) {
+        try {
+          const { data: cachedScatterChart, timestamp } = JSON.parse(cachedData);
+          const cacheAge = Date.now() - timestamp;
+          const oneHour = 60 * 60 * 1000;
+          if (cacheAge < oneHour && cachedScatterChart && cachedScatterChart.length > 0) {
+            dispatch({ type: ActionTypes.SET_SCATTER_CHART_DATA, payload: cachedScatterChart });
+            scatterPromise = Promise.resolve(cachedScatterChart);
+          }
+        } catch (e) {
+          // ignore cache parse errors
+        }
+      }
+
+      // If cache not used, fallback to API
+      if (!scatterPromise) {
+        scatterPromise = (dataMode === DATA_MODES.COUNTY
+          ? api.getCountyScatterChart()
+          : api.getRDScatterChart());
+      }
+
+      const [mapResponse, scatterResponse] = await Promise.all([
+        dataMode === DATA_MODES.COUNTY
+          ? api.getCountyResultsComparison(filters)
+          : api.getRDResultsComparison(filters),
+        scatterPromise,
+      ]);
+
+      const chartData = Array.isArray(scatterResponse)
+        ? scatterResponse
+        : scatterResponse?.data || [];
+
+      dispatch({ type: ActionTypes.SET_OBSERVED_OUTCOMES_DATA, payload: mapResponse });
+      dispatch({ type: ActionTypes.SET_SCATTER_CHART_DATA, payload: chartData });
+
+      // Cache scatter chart data for this dataMode
+      try {
+        const cacheValue = JSON.stringify({
+          data: chartData,
+          timestamp: Date.now(),
+        });
+        localStorage.setItem(cacheKey, cacheValue);
+      } catch (e) {
+        // ignore cache errors
+      }
+    } catch (error) {
+      dispatch({
+        type: ActionTypes.CLEAR_DATA_FETCH_ERROR,
+      });
+      dispatch({
+        type: ActionTypes.SET_DATA_FETCH_ERROR,
+        payload: {
+          error,
+          text: 'Failed to fetch observed outcomes page data',
+        },
+      });
+    } finally {
+      dispatch({ type: ActionTypes.FETCHING_OBSERVED_OUTCOMES_DATA, payload: false });
+      dispatch({ type: ActionTypes.FETCHING_SCATTER_CHART_DATA, payload: false });
+    }
+  };
+};

--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -38,6 +38,7 @@ import {
   getSparseData,
   getUnsummarizedData,
   runCustomPrediction,
+  fetchAllObservedOutcomesData,
 } from './data';
 
 import {
@@ -82,6 +83,7 @@ export {
   getPredictions,
   getObservedOutcomesData,
   getScatterChartData,
+  fetchAllObservedOutcomesData,
   getSparseData,
   getUnsummarizedData,
   getUserFromStorage,


### PR DESCRIPTION
# Description

This PR refactors the Observed Outcomes page to load its data more efficiently.
It introduces a single action that fetches map and scatter-chart data in parallel, adds caching for scatter data to speed up subsequent visits, and simplifies the scatter chart component so it only renders data from Redux instead of triggering its own fetches.

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

## Screenshots

Please attach any design screenshots if UI update.
