### PR TITLE
Dynamic histogram title and model version options

### DIFF
--- a/src/screens/home/components/prediction-details/component.js
+++ b/src/screens/home/components/prediction-details/component.js
@@ -21,6 +21,7 @@ const PredictionDetails = (props) => {
     onClose,
     isOpen,
     probSpotsGT50,
+    histogramFrequency,
   } = props;
 
   if (!data || data.length === 0) {
@@ -132,7 +133,7 @@ const PredictionDetails = (props) => {
           </div>
           <div className="prediction-histogram-section">
             <h3 className="prediction-histogram-title">
-              Predicted vs. Observed Outcomes for All Data, 1987-2025 (n=3,964)
+              Predicted vs. Observed Outcomes for All Data (n={histogramFrequency ?? '—'})
             </h3>
             <div className="prediction-histogram-scroll-container">
               <Histogram probSpotsGT50={probSpotsGT50} />

--- a/src/screens/home/components/prediction-details/index.js
+++ b/src/screens/home/components/prediction-details/index.js
@@ -22,6 +22,7 @@ const mapStateToProps = (state) => {
     data: predictions,
     isOpen: predictionModal,
     probSpotsGT50,
+    histogramFrequency: state.histogram?.frequency,
   };
 };
 

--- a/src/screens/play-with-model/components/play-with-model-inputs/component.js
+++ b/src/screens/play-with-model/components/play-with-model-inputs/component.js
@@ -5,8 +5,6 @@ import { ChoiceInput } from '../../../../components/input-components';
 
 import './style.scss';
 
-const MODEL_VERSION_FIRST_YEAR = 2025;
-
 const PlayWithModelInputs = (props) => {
   const {
     modelInputs,
@@ -62,24 +60,14 @@ const PlayWithModelInputs = (props) => {
   };
 
   const filterModelVersionInputs = (modelVersion) => {
-    const inputsForVersion = MODEL_VERSION_INPUTS[modelVersion] ?? MODEL_VERSION_INPUTS[defaultModelVersion];
     const filteredInputsInformation = Object.entries(INPUT_INFORMATION).filter((entry) => {
-      return inputsForVersion.includes(entry[0]);
+      return MODEL_VERSION_INPUTS[modelVersion || defaultModelVersion].includes(entry[0]);
     });
 
     return Object.fromEntries(filteredInputsInformation);
   };
 
   const inputInformation = filterModelVersionInputs(modelInputs.modelVersion);
-
-  const modelVersionOptions = [
-    2018,
-    2024,
-    ...Array.from(
-      { length: Math.max(0, new Date().getFullYear() - MODEL_VERSION_FIRST_YEAR + 1) },
-      (_, i) => MODEL_VERSION_FIRST_YEAR + i
-    ),
-  ];
 
   const selectionInput = (isTrueFalseSelection, value, setValue) => {
     if (!isTrueFalseSelection) {
@@ -89,7 +77,7 @@ const PlayWithModelInputs = (props) => {
             type="number"
             min="0"
             onChange={(e) => setValue(e.target.value)}
-            value={value}
+            value={value === undefined || value === null || Number.isNaN(value) ? '' : value}
           />
         </form>
       );
@@ -157,7 +145,7 @@ const PlayWithModelInputs = (props) => {
           <span>Pick model version</span>
           <ChoiceInput
             id="modelVersion"
-            options={modelVersionOptions}
+            options={[2018, 2024, 2025]}
             value={modelInputs.modelVersion}
             setValue={createValueSetter('modelVersion')}
             firstOptionText="Year"

--- a/src/screens/play-with-model/components/play-with-model-inputs/component.js
+++ b/src/screens/play-with-model/components/play-with-model-inputs/component.js
@@ -5,6 +5,8 @@ import { ChoiceInput } from '../../../../components/input-components';
 
 import './style.scss';
 
+const MODEL_VERSION_FIRST_YEAR = 2025;
+
 const PlayWithModelInputs = (props) => {
   const {
     modelInputs,
@@ -60,14 +62,24 @@ const PlayWithModelInputs = (props) => {
   };
 
   const filterModelVersionInputs = (modelVersion) => {
+    const inputsForVersion = MODEL_VERSION_INPUTS[modelVersion] ?? MODEL_VERSION_INPUTS[defaultModelVersion];
     const filteredInputsInformation = Object.entries(INPUT_INFORMATION).filter((entry) => {
-      return MODEL_VERSION_INPUTS[modelVersion || defaultModelVersion].includes(entry[0]);
+      return inputsForVersion.includes(entry[0]);
     });
 
     return Object.fromEntries(filteredInputsInformation);
   };
 
   const inputInformation = filterModelVersionInputs(modelInputs.modelVersion);
+
+  const modelVersionOptions = [
+    2018,
+    2024,
+    ...Array.from(
+      { length: Math.max(0, new Date().getFullYear() - MODEL_VERSION_FIRST_YEAR + 1) },
+      (_, i) => MODEL_VERSION_FIRST_YEAR + i
+    ),
+  ];
 
   const selectionInput = (isTrueFalseSelection, value, setValue) => {
     if (!isTrueFalseSelection) {
@@ -145,7 +157,7 @@ const PlayWithModelInputs = (props) => {
           <span>Pick model version</span>
           <ChoiceInput
             id="modelVersion"
-            options={[2018, 2024, 2025]}
+            options={modelVersionOptions}
             value={modelInputs.modelVersion}
             setValue={createValueSetter('modelVersion')}
             firstOptionText="Year"


### PR DESCRIPTION
# Description

Removes the hardcoded "1987-2025 (n=3,964)" text in the prediction details modal and shows the record count (n) from the histogram API. In Play With Model, adds a fallback for unknown model versions (e.g. 2026) and a dynamic year dropdown (2018, 2024, 2025… up to the current year) so the code does not need a manual update every year.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation