### PR TITLE
fix(frontend): align histogram highlight with API buckets and correct ECharts x-axis max

### DIFF
--- a/src/components/histogram-components/histogram/component.js
+++ b/src/components/histogram-components/histogram/component.js
@@ -5,15 +5,19 @@ import SingleChart from '../single-chart/component';
 import './style.scss';
 
 const updateWithBorder = (array, probSpotsGT50) => {
-  const arrayUpdated = array.map((item) => {
-    const rangeArray = item.range.split('-');
-
-    if (probSpotsGT50 >= rangeArray[0] && probSpotsGT50 < rangeArray[1]) {
+  if (probSpotsGT50 == null || Number.isNaN(Number(probSpotsGT50))) {
+    return array;
+  }
+  const p = Number(probSpotsGT50);
+  return array.map((item) => {
+    const [minStr, maxStr] = item.range.split('-');
+    const min = parseFloat(minStr);
+    const max = parseFloat(maxStr);
+    if (p > min && p <= max) {
       return { ...item, withBorder: true };
-    } else return item;
+    }
+    return item;
   });
-
-  return arrayUpdated;
 };
 
 const Histogram = ({ histogramData, getHistogram, probSpotsGT50 }) => {

--- a/src/components/histogram-components/single-chart/component.js
+++ b/src/components/histogram-components/single-chart/component.js
@@ -77,7 +77,7 @@ const SingleChart = ({
         length: 3,
         lineStyle: { color: '#000', width: 1 },
       },
-      max: data?.frequency || 0,
+      max: Number.isFinite(frequency) && frequency > 0 ? frequency : undefined,
     },
     series: [
       {


### PR DESCRIPTION
# Description

Fixes the prediction histogram modal so the highlighted column matches backend binning ((min, max] instead of [min, max)), and uses the bucket frequency prop for the horizontal bar scale instead of the invalid data.frequency reference on the counts array.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

## Screenshots

Please attach any design screenshots if UI update.
