### PR TITLE
Add upload preview/history UI and redesign admin dashboard

### DIFF
--- a/src/components/button/style.scss
+++ b/src/components/button/style.scss
@@ -10,11 +10,11 @@
 
     &-primary {
         color: $white;
-        background-color: $brandPrimary;
+        background-color: $brandSecondary;
         transition: all 0.2s ease;
 
         &:hover {
-            background-color: $brandSecondary;
+            background-color: $brandPrimary;
         }
     }
 

--- a/src/components/filter-overlay/style.scss
+++ b/src/components/filter-overlay/style.scss
@@ -97,7 +97,7 @@
 
 /* Filter Buttons */
 .filter-overlay-action-button {
-  background: $brandPrimary;
+  background: $brandSecondary;
   color: $cleanWhite;
   border: none;
   border-radius: 6px;
@@ -110,7 +110,7 @@
   letter-spacing: 0.03125rem;
 
   &:hover:not(:disabled) {
-    background: $brandSecondary;
+    background: $brandPrimary;
     transform: translateY(-0.0625rem);
   }
   &:disabled {

--- a/src/components/input-components/file-input/index.js
+++ b/src/components/input-components/file-input/index.js
@@ -2,11 +2,115 @@ import React, { useState } from 'react';
 
 import './style.scss';
 
+const REASON_LABELS = {
+  MISSING_COLLECTION_DATE: 'no collection date for this week',
+  ZERO_DAYS_ACTIVE: 'days active = 0 (trap not deployed)',
+  MARKED_DELETE: 'marked for deletion in source',
+  NOT_FINAL_COLLECTION: 'not a final collection',
+  MISSING_REQUIRED_FIELD: 'required field missing',
+  MISSING_FORMAT_FIELD: 'expected CSV format field missing',
+  ROW_PROCESSING_ERROR: 'row could not be processed',
+  ACTIVE_DAYS_OUT_OF_RANGE: 'total active days outside allowed window',
+  INVALID_NUMERIC: 'value is not a valid number',
+  INVALID_DATE: 'value is not a valid date',
+};
+
+const renderRejectedLine = (r) => {
+  const label = REASON_LABELS[r.reason] || r.reason;
+  let detail = '';
+  if (r.value) detail = ` (${r.field}: ${r.value})`;
+  else if (r.field) detail = ` (${r.field})`;
+  return `${r.identifier} — ${label}${detail}`;
+};
+
+const labelFor = (reason) => REASON_LABELS[reason] || reason;
+
+const PreviewSummary = ({
+  preview,
+  onCancel,
+  onConfirm,
+  isUploading,
+}) => {
+  const skippedGroups = preview.skipped.reduce((acc, item) => {
+    acc[item.reason] = (acc[item.reason] || 0) + 1;
+    return acc;
+  }, {});
+  const rejectedGroups = preview.rejected.reduce((acc, item) => {
+    acc[item.reason] = (acc[item.reason] || 0) + 1;
+    return acc;
+  }, {});
+
+  return (
+    <div className="upload-preview-container">
+      <h3>Preview</h3>
+      <div className="upload-preview-counts">
+        <div className="upload-preview-count upload-preview-count-accepted">
+          <span className="upload-preview-count-value">{preview.accepted}</span>
+          <span className="upload-preview-count-label">Accepted</span>
+        </div>
+        <div className="upload-preview-count upload-preview-count-skipped">
+          <span className="upload-preview-count-value">{preview.skipped.length}</span>
+          <span className="upload-preview-count-label">Skipped</span>
+        </div>
+        <div className="upload-preview-count upload-preview-count-rejected">
+          <span className="upload-preview-count-value">{preview.rejected.length}</span>
+          <span className="upload-preview-count-label">Rejected</span>
+        </div>
+      </div>
+
+      {preview.rejected.length > 0 && (
+        <details open>
+          <summary>{preview.rejected.length} rejected — action needed</summary>
+          <ul className="upload-preview-list">
+            {Object.entries(rejectedGroups).map(([reason, count]) => (
+              <li key={reason}><strong>{count}×</strong> {labelFor(reason)}</li>
+            ))}
+          </ul>
+          <ul className="upload-preview-detail">
+            {preview.rejected.slice(0, 50).map((r) => (
+              <li key={`${r.identifier}-${r.reason}-${r.field || ''}`}>{renderRejectedLine(r)}</li>
+            ))}
+            {preview.rejected.length > 50 && <li key="more">… and {preview.rejected.length - 50} more</li>}
+          </ul>
+        </details>
+      )}
+
+      {preview.skipped.length > 0 && (
+        <details>
+          <summary>{preview.skipped.length} skipped — informational</summary>
+          <ul className="upload-preview-list">
+            {Object.entries(skippedGroups).map(([reason, count]) => (
+              <li key={reason}><strong>{count}×</strong> {labelFor(reason)}</li>
+            ))}
+          </ul>
+        </details>
+      )}
+
+      <div className="upload-preview-actions">
+        <button type="button" onClick={onCancel} disabled={isUploading}>Cancel</button>
+        <button
+          type="button"
+          className="upload-preview-confirm"
+          onClick={onConfirm}
+          disabled={isUploading || preview.accepted === 0}
+        >
+          {isUploading ? 'Uploading…' : `Confirm Upload (${preview.accepted})`}
+        </button>
+      </div>
+    </div>
+  );
+};
+
 const FileInput = (props) => {
   const {
-    guideURL, component, onResetFiles, fileFormat = '.csv',
+    guideURL,
+    component,
+    onResetFiles,
+    fileFormat = '.csv',
   } = props;
 
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [preview, setPreview] = useState(null);
   const [isUploadingFile, setIsUploadingFile] = useState(false);
   const [uploadingFileError, setUploadingFileError] = useState('');
   const [successMessage, setSuccessMessage] = useState({});
@@ -17,7 +121,62 @@ const FileInput = (props) => {
     setUploadingFileError('');
     onResetFiles();
     setIsUploadingFile(false);
+    setIsPreviewing(false);
+    setPreview(null);
     setSuccessMessage({});
+  };
+
+  const handlePreview = async () => {
+    if (!component.previewFile || !component.file) {
+      // no preview available — fall back to direct upload
+      // eslint-disable-next-line no-use-before-define
+      return doUpload();
+    }
+    setIsPreviewing(true);
+    try {
+      const result = await component.previewFile(component.file);
+      setPreview(result);
+    } catch (err) {
+      const { data, status } = err?.response || {};
+      const strippedError = (data?.error || '').toString().replace('Error: ', '');
+      const badColumnNames = strippedError.includes('missing fields in csv');
+      const wrongFileFormat = strippedError.includes('Invalid file type');
+      if (badColumnNames) setUploadingFileError('Incorrect column names. Please upload a different CSV.');
+      else if (wrongFileFormat) setUploadingFileError('Invalid file type. Only CSV files are allowed.');
+      else if (status === 400) setUploadingFileError(`Bad request: ${strippedError}`);
+      else setUploadingFileError(strippedError || 'We encountered an error. Please try again.');
+    } finally {
+      setIsPreviewing(false);
+    }
+    return undefined;
+  };
+
+  const doUpload = async () => {
+    setIsUploadingFile(true);
+    try {
+      await component.uploadFile(component.file);
+      component.selectFile();
+      setPreview(null);
+      const acceptedLine = preview ? ` ${preview.accepted} accepted, ${preview.rejected.length} rejected.` : '';
+      setSuccessMessage({ [component.id]: `Successfully uploaded file.${acceptedLine}` });
+      setTimeout(clearSuccessMessage, 1000 * 7);
+    } catch (err) {
+      const { data, status } = err?.response || {};
+      const strippedError = (data?.error || '').toString().replace('Error: ', '');
+      const badColumnNames = strippedError.includes('missing fields in csv');
+      const wrongFileFormat = strippedError.includes('Invalid file type');
+      if (badColumnNames) setUploadingFileError('Incorrect column names. Please upload a different CSV.');
+      else if (wrongFileFormat) setUploadingFileError('Invalid file type. Only CSV files are allowed.');
+      else if (status === 400) setUploadingFileError(`Bad request: ${strippedError}`);
+      else setUploadingFileError(strippedError || 'We encountered an error. Please try again.');
+    } finally {
+      setIsUploadingFile(false);
+    }
+  };
+
+  const cancelPreview = () => {
+    setPreview(null);
+    component.selectFile();
   };
 
   if (isUploadingFile) {
@@ -32,10 +191,10 @@ const FileInput = (props) => {
     return (
       <div id="uploading-error-container" className="uploading-message-container">
         {
-            guideURL
-              ? <h3>{uploadingFileError} Please read <a href={guideURL} target="_blank" rel="noopener noreferrer">this guide</a> for uploading data.</h3>
-              : <h3>{uploadingFileError}</h3>
-          }
+          guideURL
+            ? <h3>{uploadingFileError} Please read <a href={guideURL} target="_blank" rel="noopener noreferrer">this guide</a> for uploading data.</h3>
+            : <h3>{uploadingFileError}</h3>
+        }
         <button
           type="button"
           onClick={clearError}
@@ -45,38 +204,20 @@ const FileInput = (props) => {
     );
   }
 
-  /**
-   * @description uploads given file
-   * @param {Function} uploadFunction function to upload file
-   * @param {File} file file object
-   * @param {Function} clearFile function to clear the file
-   * @param {String} id file id
-   */
-  const uploadFile = async (uploadFunction, file, clearFile, id) => {
-    setIsUploadingFile(true);
-
-    try {
-      await uploadFunction(file);
-      clearFile();
-      setSuccessMessage({ [id]: 'Successfully uploaded file' });
-      setTimeout(clearSuccessMessage, 1000 * 7);
-    } catch (err) {
-      const { data, status } = err?.response || {};
-
-      const strippedError = data?.error.toString().replace('Error: ', '');
-
-      const badRequest = status === 400;
-      const badColumnNames = strippedError.includes('missing fields in csv');
-      const wrongFileFormat = strippedError.includes('Invalid file type');
-
-      if (badColumnNames) setUploadingFileError('Incorrect column names. Please upload a different CSV.');
-      else if (wrongFileFormat) setUploadingFileError('Invalid file type. Only PNG, JPG, and JPEG files are allowed! Please, choose a different file.');
-      else if (badRequest) setUploadingFileError(`Bad request: ${strippedError}`);
-      else setUploadingFileError(strippedError || data?.error.toString() || 'We encountered an error. Please try again.');
-    } finally {
-      setIsUploadingFile(false);
-    }
-  };
+  if (preview) {
+    return (
+      <div id={component.id} key={component.id}>
+        <p>{component.name}</p>
+        <p id="file-selected">{component.file?.name}</p>
+        <PreviewSummary
+          preview={preview}
+          onCancel={cancelPreview}
+          onConfirm={doUpload}
+          isUploading={isUploadingFile}
+        />
+      </div>
+    );
+  }
 
   return (
     <div id={component.id} key={component.id}>
@@ -89,19 +230,16 @@ const FileInput = (props) => {
           id="upload-button"
           className="custom-file-upload"
           type="button"
-          onClick={() => uploadFile(
-            component.uploadFile,
-            component.file,
-            component.selectFile,
-            component.id
-          )}
+          onClick={handlePreview}
+          disabled={isPreviewing}
         >
-          Upload File
+          {/* eslint-disable-next-line no-nested-ternary */}
+          {isPreviewing ? 'Checking…' : (component.previewFile ? 'Preview' : 'Upload File')}
         </button>
       ) : (
         <>
           {successMessage[component.id] && (
-          <p id="success-message">{successMessage[component.id]}</p>
+            <p id="success-message">{successMessage[component.id]}</p>
           )}
           <label htmlFor={`file-upload-${component.id}`} className="custom-file-upload">
             <input

--- a/src/components/input-components/file-input/index.js
+++ b/src/components/input-components/file-input/index.js
@@ -40,6 +40,13 @@ const PreviewSummary = ({
     return acc;
   }, {});
 
+  const willDelete = preview.willDelete || 0;
+  const canConfirm = preview.accepted > 0 || willDelete > 0;
+  const confirmParts = [];
+  if (preview.accepted > 0) confirmParts.push(`${preview.accepted} add`);
+  if (willDelete > 0) confirmParts.push(`${willDelete} delete`);
+  const confirmLabel = confirmParts.length ? `Confirm Upload (${confirmParts.join(' · ')})` : 'Confirm Upload';
+
   return (
     <div className="upload-preview-container">
       <h3>Preview</h3>
@@ -86,15 +93,21 @@ const PreviewSummary = ({
         </details>
       )}
 
+      {willDelete > 0 && (
+        <p className="upload-preview-delete-note">
+          {willDelete} existing {willDelete === 1 ? 'survey' : 'surveys'} will be removed and replaced.
+        </p>
+      )}
+
       <div className="upload-preview-actions">
         <button type="button" onClick={onCancel} disabled={isUploading}>Cancel</button>
         <button
           type="button"
           className="upload-preview-confirm"
           onClick={onConfirm}
-          disabled={isUploading || preview.accepted === 0}
+          disabled={isUploading || !canConfirm}
         >
-          {isUploading ? 'Uploading…' : `Confirm Upload (${preview.accepted})`}
+          {isUploading ? 'Uploading…' : confirmLabel}
         </button>
       </div>
     </div>

--- a/src/components/input-components/file-input/index.js
+++ b/src/components/input-components/file-input/index.js
@@ -171,8 +171,14 @@ const FileInput = (props) => {
       await component.uploadFile(component.file);
       component.selectFile();
       setPreview(null);
-      const acceptedLine = preview ? ` ${preview.accepted} accepted, ${preview.rejected.length} rejected.` : '';
-      setSuccessMessage({ [component.id]: `Successfully uploaded file.${acceptedLine}` });
+      const accepted = preview?.accepted ?? 0;
+      const rejectedLen = preview?.rejected?.length ?? 0;
+      // When zero rows were accepted, calling this a "success" misleads the
+      // user — switch the lead to surface that nothing was written.
+      const message = accepted === 0
+        ? `No rows accepted. ${rejectedLen} rejected — check details below.`
+        : `Successfully uploaded file. ${accepted} accepted, ${rejectedLen} rejected.`;
+      setSuccessMessage({ [component.id]: message });
       setTimeout(clearSuccessMessage, 1000 * 7);
       if (onUploadComplete) onUploadComplete();
     } catch (err) {

--- a/src/components/input-components/file-input/index.js
+++ b/src/components/input-components/file-input/index.js
@@ -106,6 +106,7 @@ const FileInput = (props) => {
     guideURL,
     component,
     onResetFiles,
+    onUploadComplete,
     fileFormat = '.csv',
   } = props;
 
@@ -160,6 +161,7 @@ const FileInput = (props) => {
       const acceptedLine = preview ? ` ${preview.accepted} accepted, ${preview.rejected.length} rejected.` : '';
       setSuccessMessage({ [component.id]: `Successfully uploaded file.${acceptedLine}` });
       setTimeout(clearSuccessMessage, 1000 * 7);
+      if (onUploadComplete) onUploadComplete();
     } catch (err) {
       const { data, status } = err?.response || {};
       const strippedError = (data?.error || '').toString().replace('Error: ', '');
@@ -206,8 +208,8 @@ const FileInput = (props) => {
 
   if (preview) {
     return (
-      <div id={component.id} key={component.id}>
-        <p>{component.name}</p>
+      <div id={component.id} className="upload-item" key={component.id}>
+        <p className="upload-item-name">{component.name}</p>
         <p id="file-selected">{component.file?.name}</p>
         <PreviewSummary
           preview={preview}
@@ -220,38 +222,40 @@ const FileInput = (props) => {
   }
 
   return (
-    <div id={component.id} key={component.id}>
-      <p>{component.name}</p>
-      <p id="file-selected">
-        {component.file ? component.file.name : ''}
-      </p>
-      {component.file && component.uploadFile ? (
-        <button
-          id="upload-button"
-          className="custom-file-upload"
-          type="button"
-          onClick={handlePreview}
-          disabled={isPreviewing}
-        >
-          {/* eslint-disable-next-line no-nested-ternary */}
-          {isPreviewing ? 'Checking…' : (component.previewFile ? 'Preview' : 'Upload File')}
-        </button>
-      ) : (
-        <>
-          {successMessage[component.id] && (
+    <div id={component.id} className="upload-item" key={component.id}>
+      <div className="upload-item-row">
+        <div className="upload-item-info">
+          <p className="upload-item-name">{component.name}</p>
+          {component.file && <p id="file-selected">{component.file.name}</p>}
+          {!component.file && successMessage[component.id] && (
             <p id="success-message">{successMessage[component.id]}</p>
           )}
-          <label htmlFor={`file-upload-${component.id}`} className="custom-file-upload">
-            <input
-              id={`file-upload-${component.id}`}
-              type="file"
-              accept={fileFormat}
-              onChange={(e) => component.selectFile(e.target.files[0]) && clearSuccessMessage()}
-            />
-            Select File
-          </label>
-        </>
-      )}
+        </div>
+        <div className="upload-item-action">
+          {component.file && component.uploadFile ? (
+            <button
+              id="upload-button"
+              className="custom-file-upload"
+              type="button"
+              onClick={handlePreview}
+              disabled={isPreviewing}
+            >
+              {/* eslint-disable-next-line no-nested-ternary */}
+              {isPreviewing ? 'Checking…' : (component.previewFile ? 'Preview' : 'Upload File')}
+            </button>
+          ) : (
+            <label htmlFor={`file-upload-${component.id}`} className="custom-file-upload">
+              <input
+                id={`file-upload-${component.id}`}
+                type="file"
+                accept={fileFormat}
+                onChange={(e) => component.selectFile(e.target.files[0]) && clearSuccessMessage()}
+              />
+              Select File
+            </label>
+          )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/src/components/input-components/file-input/style.scss
+++ b/src/components/input-components/file-input/style.scss
@@ -47,6 +47,97 @@ input[type=file] {
     margin-top: -5px !important;
 }
 
+.upload-preview-container {
+    margin-top: 12px;
+    padding: 12px;
+    border: 1px solid $greyBlue400;
+    border-radius: 8px;
+    background: rgba(255, 255, 255, 0.6);
+
+    h3 {
+        margin: 0 0 8px;
+        font-size: 16px;
+    }
+
+    details {
+        margin-top: 8px;
+
+        summary {
+            cursor: pointer;
+            font-weight: 600;
+        }
+    }
+
+    .upload-preview-list,
+    .upload-preview-detail {
+        margin: 6px 0 0;
+        padding-left: 18px;
+        font-size: 13px;
+    }
+
+    .upload-preview-detail {
+        max-height: 180px;
+        overflow-y: auto;
+        font-family: 'Menlo', 'Monaco', monospace;
+    }
+}
+
+.upload-preview-counts {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 8px;
+}
+
+.upload-preview-count {
+    flex: 1;
+    padding: 8px;
+    border-radius: 6px;
+    text-align: center;
+    background: $greyBlue400;
+
+    .upload-preview-count-value {
+        display: block;
+        font-size: 22px;
+        font-weight: 700;
+    }
+
+    .upload-preview-count-label {
+        display: block;
+        font-size: 12px;
+        text-transform: uppercase;
+    }
+}
+
+.upload-preview-count-accepted { background: #d4edda; }
+.upload-preview-count-skipped { background: #e2e3e5; }
+.upload-preview-count-rejected { background: #f8d7da; }
+
+.upload-preview-actions {
+    display: flex;
+    gap: 8px;
+    margin-top: 12px;
+
+    button {
+        flex: 1;
+        padding: 8px 12px;
+        border: none;
+        border-radius: 6px;
+        cursor: pointer;
+        font-weight: 600;
+        background: $greyBlue400;
+    }
+
+    button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+
+    .upload-preview-confirm {
+        background: $blue500;
+        color: $white;
+    }
+}
+
 #uploading-error-container {
     h3 {
         color: $red500;

--- a/src/components/input-components/file-input/style.scss
+++ b/src/components/input-components/file-input/style.scss
@@ -144,6 +144,13 @@ input[type=file] {
     color: $statusDanger;
 }
 
+.upload-preview-delete-note {
+    margin: 0.5rem 0 0;
+    font-size: 0.8125rem;
+    color: $statusWarning;
+    font-weight: 600;
+}
+
 .upload-preview-actions {
     display: flex;
     gap: 0.5rem;

--- a/src/components/input-components/file-input/style.scss
+++ b/src/components/input-components/file-input/style.scss
@@ -10,22 +10,46 @@ input[type=file] {
     display: none;
 }
 
+// Secondary button (white + grey border) — base for "Select File".
 .custom-file-upload {
-    display: inline-block;
-    padding: 6px 15px 5px;
-    border-radius: 6px;
-    background-color: $greyBlue400;
-    font-size: 18px;
-    line-height: 1.8;
-    color: $black;
-    margin-top: 8px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.25rem;
+    padding: 0.375rem 0.875rem;
+    border-radius: 8px;
+    border: 1px solid $greyBlue400;
+    background-color: $white;
+    color: $greyBlue900;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    line-height: 1.2;
+    margin-top: 0.5rem;
     cursor: pointer;
-    border: 0;
     font-family: 'Inter';
+    transition: background-color 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+
+    &:hover {
+        background-color: $greyBlue100;
+        border-color: $greyBlue500;
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
 }
 
+// Primary button (sage green, matching the app's action buttons).
 #upload-button {
-    background-color: $blue500;
+    border-color: $brandSecondary;
+    background-color: $brandSecondary;
+    color: $white;
+
+    &:hover {
+        background-color: $brandPrimary;
+        border-color: $brandPrimary;
+    }
 }
 
 .uploading-message-container {
@@ -43,24 +67,25 @@ input[type=file] {
 }
 
 #success-message {
-    color: $blue500;
+    color: $statusSuccess;
+    font-weight: 600;
     margin-top: -5px !important;
 }
 
 .upload-preview-container {
-    margin-top: 12px;
-    padding: 12px;
-    border: 1px solid $greyBlue400;
-    border-radius: 8px;
-    background: rgba(255, 255, 255, 0.6);
+    margin-top: 0.75rem;
+    padding: 0.75rem;
+    border: 1px solid $greyBlue300;
+    border-radius: 10px;
+    background: $white;
 
     h3 {
-        margin: 0 0 8px;
-        font-size: 16px;
+        margin: 0 0 0.5rem;
+        font-size: 1rem;
     }
 
     details {
-        margin-top: 8px;
+        margin-top: 0.5rem;
 
         summary {
             cursor: pointer;
@@ -70,61 +95,69 @@ input[type=file] {
 
     .upload-preview-list,
     .upload-preview-detail {
-        margin: 6px 0 0;
-        padding-left: 18px;
-        font-size: 13px;
-    }
-
-    .upload-preview-detail {
-        max-height: 180px;
-        overflow-y: auto;
-        font-family: 'Menlo', 'Monaco', monospace;
+        margin: 0.375rem 0 0;
+        padding-left: 1.125rem;
+        font-size: 0.8125rem;
+        line-height: 1.6;
     }
 }
 
 .upload-preview-counts {
     display: flex;
-    gap: 12px;
-    margin-bottom: 8px;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
 }
 
 .upload-preview-count {
     flex: 1;
-    padding: 8px;
-    border-radius: 6px;
+    padding: 0.5rem;
+    border-radius: 8px;
     text-align: center;
-    background: $greyBlue400;
+    background: $greyBlue200;
 
     .upload-preview-count-value {
         display: block;
-        font-size: 22px;
+        font-size: 1.375rem;
         font-weight: 700;
     }
 
     .upload-preview-count-label {
         display: block;
-        font-size: 12px;
+        font-size: 0.75rem;
         text-transform: uppercase;
+        letter-spacing: 0.02em;
     }
 }
 
-.upload-preview-count-accepted { background: #d4edda; }
-.upload-preview-count-skipped { background: #e2e3e5; }
-.upload-preview-count-rejected { background: #f8d7da; }
+.upload-preview-count-accepted {
+    background: $statusSuccessBg;
+    color: $statusSuccess;
+}
+
+.upload-preview-count-skipped {
+    background: $greyBlue200;
+    color: $greyBlue800;
+}
+
+.upload-preview-count-rejected {
+    background: $statusDangerBg;
+    color: $statusDanger;
+}
 
 .upload-preview-actions {
     display: flex;
-    gap: 8px;
-    margin-top: 12px;
+    gap: 0.5rem;
+    margin-top: 0.75rem;
 
     button {
         flex: 1;
-        padding: 8px 12px;
-        border: none;
-        border-radius: 6px;
+        min-height: 2.75rem;
+        padding: 0.5rem 0.75rem;
+        border: 1px solid $greyBlue400;
+        border-radius: 8px;
         cursor: pointer;
         font-weight: 600;
-        background: $greyBlue400;
+        background: $white;
     }
 
     button:disabled {
@@ -133,8 +166,14 @@ input[type=file] {
     }
 
     .upload-preview-confirm {
-        background: $blue500;
+        border-color: $brandSecondary;
+        background: $brandSecondary;
         color: $white;
+
+        &:hover:not(:disabled) {
+            background: $brandPrimary;
+            border-color: $brandPrimary;
+        }
     }
 }
 
@@ -145,21 +184,22 @@ input[type=file] {
     }
 
     button {
-        width: 100px;
-        border: none;
-        padding: 10px;
-        background-color: $greyBlue400;
-        font-size: 14px;
+        min-height: 2.75rem;
+        padding: 0.5rem 1rem;
+        border: 1px solid $greyBlue400;
+        background-color: $white;
+        font-size: 0.9375rem;
         font-weight: 600;
-        color: $greyBlue800;
+        color: $greyBlue900;
         border-radius: 8px;
-        margin-top: 20px;
+        margin: 1.25rem auto 0;
         display: block;
-        margin-left: auto;
-        margin-right: auto;
+        cursor: pointer;
+        transition: background-color 0.15s ease, border-color 0.15s ease;
     }
 
     button:hover {
-        cursor: pointer;
+        background-color: $greyBlue100;
+        border-color: $greyBlue500;
     }
 }

--- a/src/screens/admin/component.js
+++ b/src/screens/admin/component.js
@@ -6,6 +6,7 @@ import {
   ChangePassword,
   FileUpload,
   Login,
+  UploadHistory,
   UserSection,
 } from './components';
 
@@ -112,6 +113,9 @@ const Admin = (props) => {
               </div>
               )}
             </div>
+          </div>
+          <div className="upload-history-section">
+            <UploadHistory />
           </div>
           <div className="blog-container">
             <AddBlogPost />

--- a/src/screens/admin/component.js
+++ b/src/screens/admin/component.js
@@ -44,12 +44,11 @@ const Admin = (props) => {
 
   const tabRefs = useRef([]);
 
-  // Refresh the upload history after a successful upload. County / ranger-district
-  // uploads write their audit row synchronously (immediate bump catches them);
-  // Survey123 processes in the background, so a short delayed bump catches that row.
+  // Refresh the upload history after an upload completes. The upload service
+  // resolves only once the audit row exists (sync for county/RD; polled to
+  // completion for Survey123), so a single bump is enough — no timers.
   const handleUploadComplete = () => {
     setHistoryRefreshKey((k) => k + 1);
-    setTimeout(() => setHistoryRefreshKey((k) => k + 1), 4000);
   };
 
   const onTabKeyDown = (e, index) => {

--- a/src/screens/admin/component.js
+++ b/src/screens/admin/component.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 
 import {
   AddBlogPost,
@@ -15,6 +15,12 @@ import { runPipeline, updateHistogram } from '../../services/admin';
 import './style.scss';
 
 const guideURL = 'https://docs.google.com/document/u/1/d/e/2PACX-1vS-VkOBKcB3_nAsyIYUU-ogG-zezQd-XZmDt5SFqMPd6OkrpRXGtoa1_Fr0gDL6LBIwzQI9A6Ix3JKr/pub';
+
+const TABS = [
+  { id: 'data', label: 'Data' },
+  { id: 'users', label: 'Users' },
+  { id: 'blog', label: 'Blog' },
+];
 
 const Admin = (props) => {
   const {
@@ -33,6 +39,32 @@ const Admin = (props) => {
   const [updatingHistogram, setUpdatingHistogram] = useState(false);
   const [modelError, setModelError] = useState('');
   const [histogramError, setHistogramError] = useState('');
+  const [activeTab, setActiveTab] = useState('data');
+  const [historyRefreshKey, setHistoryRefreshKey] = useState(0);
+
+  const tabRefs = useRef([]);
+
+  // Refresh the upload history after a successful upload. County / ranger-district
+  // uploads write their audit row synchronously (immediate bump catches them);
+  // Survey123 processes in the background, so a short delayed bump catches that row.
+  const handleUploadComplete = () => {
+    setHistoryRefreshKey((k) => k + 1);
+    setTimeout(() => setHistoryRefreshKey((k) => k + 1), 4000);
+  };
+
+  const onTabKeyDown = (e, index) => {
+    let nextIndex = null;
+    if (e.key === 'ArrowRight') nextIndex = (index + 1) % TABS.length;
+    else if (e.key === 'ArrowLeft') nextIndex = (index - 1 + TABS.length) % TABS.length;
+    else if (e.key === 'Home') nextIndex = 0;
+    else if (e.key === 'End') nextIndex = TABS.length - 1;
+
+    if (nextIndex !== null) {
+      e.preventDefault();
+      setActiveTab(TABS[nextIndex].id);
+      tabRefs.current[nextIndex]?.focus();
+    }
+  };
 
   const runAllModels = async () => {
     setModelError('');
@@ -62,74 +94,124 @@ const Admin = (props) => {
 
   if (!isLoggedIn) {
     return <Login />;
-  } else {
-    return (
-      <div id="auth-container">
-        <h1>Admin Dashboard</h1>
-        <div id="auth-header">
-          <p>Hi, {lastName ? `${firstName} ${lastName}` : firstName}!</p>
-          <p>Before uploading any data, please read <a href={guideURL} target="_blank" rel="noopener noreferrer">this guide</a>.</p>
-          <div id="header-options">
-            <p id="sign-out" onClick={signOut}>Sign Out</p>
-            <p id="change-password" onClick={() => setChangePasswordVisible(true)}>Change Password</p>
-          </div>
+  }
+
+  return (
+    <div id="auth-container">
+      <header className="admin-topbar">
+        <div className="admin-topbar-heading">
+          <h1>Admin Dashboard</h1>
+          <p className="admin-greeting">Hi, {lastName ? `${firstName} ${lastName}` : firstName}!</p>
         </div>
-        <div id="dashboard-container">
-          <div id="dashboard">
-            <div id="upload-container"><FileUpload guideURL={guideURL} /></div>
-            <UserSection />
-          </div>
-          <div className="dashboard-buttons-container">
-            <div className="button">
-              <button
-                className="animated-button"
-                disabled={runningModels}
-                id="rerun-button"
-                onClick={runAllModels}
-                type="button"
-              >
-                {runningModels ? 'Running...' : 'Rerun all models'}
-              </button>
-              {modelError && (
-              <div id="model-error-container">
-                <p>{modelError}</p>
-              </div>
-              )}
+        <div className="admin-topbar-actions">
+          <button type="button" className="admin-link-button" onClick={() => setChangePasswordVisible(true)}>
+            Change Password
+          </button>
+          <button type="button" className="admin-link-button" onClick={signOut}>
+            Sign Out
+          </button>
+        </div>
+      </header>
+
+      <div className="admin-tabs" role="tablist" aria-label="Admin sections">
+        {TABS.map((tab, index) => (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            id={`tab-${tab.id}`}
+            aria-selected={activeTab === tab.id}
+            aria-controls={`panel-${tab.id}`}
+            tabIndex={activeTab === tab.id ? 0 : -1}
+            ref={(el) => { tabRefs.current[index] = el; }}
+            className={`admin-tab${activeTab === tab.id ? ' admin-tab--active' : ''}`}
+            onClick={() => setActiveTab(tab.id)}
+            onKeyDown={(e) => onTabKeyDown(e, index)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {activeTab === 'data' && (
+        <div id="panel-data" role="tabpanel" aria-labelledby="tab-data" className="admin-grid">
+          <section className="admin-card" aria-labelledby="uploads-heading">
+            <div className="admin-card-head">
+              <h2 id="uploads-heading">Data Uploads</h2>
+              <p className="admin-card-note">
+                Before uploading, please read <a href={guideURL} target="_blank" rel="noopener noreferrer">this guide</a>.
+              </p>
             </div>
-            <div className="button">
-              <button
-                className="animated-button"
-                disabled={updatingHistogram}
-                id="update-histogram-button"
-                onClick={runUpdateHistogram}
-                type="button"
-              >
-                {updatingHistogram ? 'Updating...' : 'Update histogram'}
-              </button>
-              {histogramError && (
-              <div id="histogram-error-container">
-                <span className="error-mark">!</span>
-                <p>{histogramError}</p>
-              </div>
-              )}
+            <FileUpload guideURL={guideURL} onUploadComplete={handleUploadComplete} />
+          </section>
+
+          <section className="admin-card" aria-labelledby="history-heading">
+            <div className="admin-card-head">
+              <h2 id="history-heading">Upload History</h2>
             </div>
-          </div>
-          <div className="upload-history-section">
-            <UploadHistory />
-          </div>
-          <div className="blog-container">
+            <UploadHistory refreshKey={historyRefreshKey} />
+          </section>
+
+          <section className="admin-card" aria-labelledby="actions-heading">
+            <div className="admin-card-head">
+              <h2 id="actions-heading">Pipeline Actions</h2>
+              <p className="admin-card-note">Re-run predictions or refresh the histogram after uploading new data.</p>
+            </div>
+            <div className="admin-actions">
+              <div className="admin-action">
+                <button
+                  className="admin-button"
+                  disabled={runningModels}
+                  onClick={runAllModels}
+                  type="button"
+                >
+                  {runningModels ? 'Running…' : 'Rerun all models'}
+                </button>
+                {modelError && <p className="admin-action-error" role="alert">{modelError}</p>}
+              </div>
+              <div className="admin-action">
+                <button
+                  className="admin-button"
+                  disabled={updatingHistogram}
+                  onClick={runUpdateHistogram}
+                  type="button"
+                >
+                  {updatingHistogram ? 'Updating…' : 'Update histogram'}
+                </button>
+                {histogramError && <p className="admin-action-error" role="alert">{histogramError}</p>}
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
+
+      {activeTab === 'users' && (
+        <div id="panel-users" role="tabpanel" aria-labelledby="tab-users" className="admin-grid">
+          <section className="admin-card" aria-labelledby="users-heading">
+            <div className="admin-card-head">
+              <h2 id="users-heading">Users</h2>
+            </div>
+            <UserSection activeUser={user} />
+          </section>
+        </div>
+      )}
+
+      {activeTab === 'blog' && (
+        <div id="panel-blog" role="tabpanel" aria-labelledby="tab-blog" className="admin-grid">
+          <div className="admin-blog-stack">
             <AddBlogPost />
             <BlogPosts />
           </div>
         </div>
-        <ChangePassword
-          close={() => setChangePasswordVisible(false)}
-          open={() => setChangePasswordVisible(true)}
-          visible={changePasswordVisible}
-        />
-      </div>
-    );
-  }
+      )}
+
+      <ChangePassword
+        close={() => setChangePasswordVisible(false)}
+        open={() => setChangePasswordVisible(true)}
+        visible={changePasswordVisible}
+      />
+    </div>
+  );
 };
 
 export default Admin;

--- a/src/screens/admin/components/add-user/component.js
+++ b/src/screens/admin/components/add-user/component.js
@@ -65,7 +65,7 @@ const AddUser = ({ setUsers }) => {
 
   return (
     <>
-      <p id="sign-up-title">Add a new user</p>
+      <h3 id="sign-up-title">Add a new user</h3>
       <div id="input-fields">
         {success && (
           <p id="success-message">Successfully added user</p>

--- a/src/screens/admin/components/add-user/style.scss
+++ b/src/screens/admin/components/add-user/style.scss
@@ -2,14 +2,14 @@
 @import '../../../../styles/colors';
 
 #sign-up-title {
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: $headingColor;
-    margin-bottom: 1.25rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: $greyBlue800;
+    margin: 0 0 0.875rem;
 
     @media (max-width: $mobile) {
-        font-size: 1.125rem;
-        margin-bottom: 1rem;
+        font-size: 0.9375rem;
+        margin-bottom: 0.75rem;
     }
 }
 
@@ -115,12 +115,12 @@
 #add-user-button {
     width: 7.125rem;
     margin: 1.25rem auto 0;
-    padding: 0.625rem 1.25rem;
+    padding: 0.5rem 1.25rem;
     border-radius: 0.5rem;
-    background-color: $brandPrimary;
-    font-size: 1.125rem;
-    font-weight: 600;
-    line-height: 1.8;
+    background-color: $brandSecondary;
+    font-size: 1rem;
+    font-weight: 500;
+    line-height: 1.2;
     color: $white;
     border: none;
     transition: all 0.2s ease;
@@ -130,13 +130,13 @@
     @media (max-width: $mobile) {
         width: 100%;
         max-width: 12.5rem;
-        padding: 0.625rem 0.875rem;
+        padding: 0.5rem 0.875rem;
         font-size: 0.9375rem;
         margin: 1rem auto 0;
     }
 
     &:hover:not(:disabled) {
-        background-color: $brandSecondary;
+        background-color: $brandPrimary;
         transform: translateY(-1px);
         box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
     }

--- a/src/screens/admin/components/blog-post-form/component.js
+++ b/src/screens/admin/components/blog-post-form/component.js
@@ -70,9 +70,9 @@ const BlogPostForm = (props) => {
 
   return (
     <div className="add-blog-post-container">
-      <div className="blog-posts-form-title">
+      <h2 className="blog-posts-form-title">
         {formTitle}
-      </div>
+      </h2>
       <form>
         <label htmlFor="title" className="input-label">
           Title

--- a/src/screens/admin/components/blog-post-form/style.scss
+++ b/src/screens/admin/components/blog-post-form/style.scss
@@ -4,12 +4,12 @@
 .blog-form-button {
     width: 7.125rem;
     margin: 1.25rem auto 0;
-    padding: 0.625rem 1.25rem;
+    padding: 0.5rem 1.25rem;
     border-radius: 0.5rem;
-    background-color: $brandPrimary;
-    font-size: 1.125rem;
-    font-weight: 600;
-    line-height: 1.8;
+    background-color: $brandSecondary;
+    font-size: 1rem;
+    font-weight: 500;
+    line-height: 1.2;
     color: $white;
     border: none;
     transition: all 0.2s ease;
@@ -25,7 +25,7 @@
     }
 
     &:hover:not(:disabled) {
-        background-color: $brandSecondary;
+        background-color: $brandPrimary;
         transform: translateY(-1px);
         box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
     }
@@ -154,17 +154,6 @@
     @media (min-width: $tablet) {
         flex-direction: row;
         align-items: flex-start;
-    }
-
-    label {
-        font-size: 0.875rem;
-        padding: 0.5rem;
-        border-radius: 0.5rem;
-
-        @media (max-width: $mobile) {
-            font-size: 0.8125rem;
-            padding: 0.4375rem;
-        }
     }
 }
 

--- a/src/screens/admin/components/blog-posts/component.js
+++ b/src/screens/admin/components/blog-posts/component.js
@@ -69,7 +69,7 @@ const BlogPosts = (props) => {
 
   return (
     <div className="blog-posts-container">
-      <div className="blog-posts-title">Your blog posts</div>
+      <h2 className="blog-posts-title">Your blog posts</h2>
       {sortedBlogPosts.length > 0
         ? sortedBlogPosts.map(
           (post) => <BlogPost post={post} onClickEdit={() => openEditForm(post)} onDelete={() => openDeleteModal(post)} key={post.id} />

--- a/src/screens/admin/components/blog-posts/style.scss
+++ b/src/screens/admin/components/blog-posts/style.scss
@@ -134,11 +134,11 @@
         }
 
         &:first-child {
-            background-color: $brandPrimary;
+            background-color: $brandSecondary;
             color: $white;
 
             &:hover:not(:disabled) {
-                background-color: $brandSecondary;
+                background-color: $brandPrimary;
                 transform: translateY(-1px);
                 box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
             }

--- a/src/screens/admin/components/change-password/style.scss
+++ b/src/screens/admin/components/change-password/style.scss
@@ -122,7 +122,7 @@
             margin: 1.25rem auto 0;
             padding: 0.625rem 1.25rem;
             border-radius: 0.5rem;
-            background-color: $brandPrimary;
+            background-color: $brandSecondary;
             border: 0;
             font-family: "Inter";
             font-size: 1rem;
@@ -140,7 +140,7 @@
             }
 
             &:hover:not(:disabled) {
-                background-color: $brandSecondary;
+                background-color: $brandPrimary;
                 transform: translateY(-1px);
                 box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
             }

--- a/src/screens/admin/components/delete-modal/style.scss
+++ b/src/screens/admin/components/delete-modal/style.scss
@@ -28,7 +28,7 @@
     .single-button {
         padding: 0.625rem 1.25rem;
         border-radius: 0.5rem;
-        background-color: $brandPrimary;
+        background-color: $brandSecondary;
         color: $white;
         font-size: 1rem;
         font-weight: 600;
@@ -37,7 +37,7 @@
         cursor: pointer;
 
         &:hover:not(:disabled) {
-            background-color: $brandSecondary;
+            background-color: $brandPrimary;
             transform: translateY(-1px);
             box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
         }

--- a/src/screens/admin/components/file-upload/component.js
+++ b/src/screens/admin/components/file-upload/component.js
@@ -11,7 +11,7 @@ import {
 } from '../../../../services/admin';
 
 const FileUpload = (props) => {
-  const { guideURL } = props;
+  const { guideURL, onUploadComplete } = props;
 
   const [countySpotFile, setCountySpotFile] = useState();
   const [rdSpotFile, setRdSpotFile] = useState();
@@ -41,17 +41,17 @@ const FileUpload = (props) => {
   }];
 
   return (
-    <>
+    <div className="admin-upload-list">
       {componentsToRender.map((component) => (
         <FileInput
           component={component}
           onResetFiles={() => component.selectFile()}
+          onUploadComplete={onUploadComplete}
           guideURL={guideURL}
           key={component.id}
-
         />
       ))}
-    </>
+    </div>
   );
 };
 

--- a/src/screens/admin/components/file-upload/component.js
+++ b/src/screens/admin/components/file-upload/component.js
@@ -2,6 +2,9 @@ import React, { useState } from 'react';
 
 import { FileInput } from '../../../../components/input-components';
 import {
+  previewCountySpotCsv,
+  previewRangerDistrictSpotCsv,
+  previewSurvey123UnsummarizedCsv,
   uploadCountySpotCsv,
   uploadRangerDistrictSpotCsv,
   uploadSurvey123UnsummarizedCsv,
@@ -19,18 +22,21 @@ const FileUpload = (props) => {
     id: 'county-spot',
     name: 'Upload File for County Spot Data',
     selectFile: setCountySpotFile,
+    previewFile: previewCountySpotCsv,
     uploadFile: uploadCountySpotCsv,
   }, {
     file: rdSpotFile,
     id: 'rd-spot',
     name: 'Upload File for Ranger District Spot Data',
     selectFile: setRdSpotFile,
+    previewFile: previewRangerDistrictSpotCsv,
     uploadFile: uploadRangerDistrictSpotCsv,
   }, {
     file: unsummarizedFile,
     id: 'unsummarized',
     name: 'Upload File for Survey123 Unsummarized Data',
     selectFile: setUnsummarizedFile,
+    previewFile: previewSurvey123UnsummarizedCsv,
     uploadFile: uploadSurvey123UnsummarizedCsv,
   }];
 

--- a/src/screens/admin/components/index.js
+++ b/src/screens/admin/components/index.js
@@ -4,6 +4,7 @@ import BlogPosts from './blog-posts';
 import ChangePassword from './change-password';
 import FileUpload from './file-upload';
 import Login from './login';
+import UploadHistory from './upload-history';
 import Users from './users';
 import UserSection from './user-section';
 
@@ -14,6 +15,7 @@ export {
   ChangePassword,
   FileUpload,
   Login,
+  UploadHistory,
   Users,
   UserSection,
 };

--- a/src/screens/admin/components/login/style.scss
+++ b/src/screens/admin/components/login/style.scss
@@ -149,7 +149,7 @@
             width: 150px;
             border: none;
             padding: 0.625rem 1.25rem;
-            background-color: $brandPrimary;
+            background-color: $brandSecondary;
             font-size: 1.125rem;
             font-weight: 600;
             color: $white;
@@ -162,7 +162,7 @@
             cursor: pointer;
 
             &:hover:not(:disabled) {
-                background-color: $brandSecondary;
+                background-color: $brandPrimary;
                 transform: translateY(-1px);
                 box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
             }

--- a/src/screens/admin/components/login/style.scss
+++ b/src/screens/admin/components/login/style.scss
@@ -103,9 +103,14 @@
         }
 
         #forgot-password {
+            display: block;
+            width: 100%;
+            max-width: 300px;
+            margin: 0.625rem auto 0;
+            padding: 0;
+            text-align: right;
             font-size: 0.875rem;
             color: $brandPrimary;
-            margin-top: 0.625rem;
             background-color: transparent;
             border: 0;
             text-decoration: underline;
@@ -114,6 +119,10 @@
 
             &:hover {
                 color: $brandSecondary;
+            }
+
+            @media (max-width: $tablet) {
+                max-width: 100%;
             }
         }
 

--- a/src/screens/admin/components/login/style.scss
+++ b/src/screens/admin/components/login/style.scss
@@ -108,7 +108,7 @@
             max-width: 300px;
             margin: 0.625rem auto 0;
             padding: 0;
-            text-align: right;
+            text-align: center;
             font-size: 0.875rem;
             color: $brandPrimary;
             background-color: transparent;

--- a/src/screens/admin/components/upload-history/component.js
+++ b/src/screens/admin/components/upload-history/component.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { ChoiceInput } from '../../../../components/input-components';
 import { getUploadHistory, getUploadAudit } from '../../../../services/admin';
 
 const SOURCE_LABELS = {
@@ -10,10 +11,10 @@ const SOURCE_LABELS = {
   'summarized-rangerdistrict-spots': 'Ranger District Spots',
 };
 
-const STATUS_COLORS = {
-  success: '#198754',
-  partial: '#fd7e14',
-  failed: '#dc3545',
+const STATUS_LABELS = {
+  success: 'Success',
+  partial: 'Partial',
+  failed: 'Failed',
 };
 
 const formatDate = (iso) => {
@@ -22,20 +23,32 @@ const formatDate = (iso) => {
   return d.toLocaleString();
 };
 
-const UploadHistory = () => {
+const PAGE_SIZE = 20;
+
+const UploadHistory = ({ refreshKey }) => {
   const [entries, setEntries] = useState([]);
+  const [pagination, setPagination] = useState(null);
+  const [page, setPage] = useState(1);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [expandedId, setExpandedId] = useState(null);
   const [expandedDetail, setExpandedDetail] = useState(null);
 
-  const load = async () => {
+  const load = async (targetPage = 1) => {
     setLoading(true);
     setError('');
     try {
-      const result = await getUploadHistory({ limit: 50, status: statusFilter || undefined });
+      const result = await getUploadHistory({
+        page: targetPage,
+        limit: PAGE_SIZE,
+        status: statusFilter || undefined,
+      });
       setEntries(result?.data || []);
+      setPagination(result?.pagination || null);
+      setPage(targetPage);
+      setExpandedId(null);
+      setExpandedDetail(null);
     } catch (err) {
       setError(err?.response?.data?.error?.toString() || 'Failed to load upload history');
     } finally {
@@ -44,9 +57,9 @@ const UploadHistory = () => {
   };
 
   useEffect(() => {
-    load();
+    load(1);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [statusFilter]);
+  }, [statusFilter, refreshKey]);
 
   const toggleDetail = async (uploadId) => {
     if (expandedId === uploadId) {
@@ -66,97 +79,150 @@ const UploadHistory = () => {
 
   return (
     <div id="upload-history-container">
-      <div className="upload-history-header">
-        <h3>Upload History</h3>
-        <div>
-          <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)}>
-            <option value="">All</option>
-            <option value="success">Success</option>
-            <option value="partial">Partial</option>
-            <option value="failed">Failed</option>
-          </select>
-          <button type="button" onClick={load} disabled={loading} style={{ marginLeft: 8 }}>
-            {loading ? '...' : 'Refresh'}
+      <div className="upload-history-toolbar">
+        <p className="upload-history-intro">
+          Recent CSV uploads with accepted, skipped, and rejected row counts.
+        </p>
+        <div className="upload-history-controls">
+          <div className="upload-history-filter">
+            <span className="upload-history-filter-label">Status</span>
+            <ChoiceInput
+              id="upload-history-status"
+              options={['Success', 'Partial', 'Failed']}
+              value={STATUS_LABELS[statusFilter] || ''}
+              setValue={(label) => setStatusFilter(label ? label.toLowerCase() : '')}
+              firstOptionText="All"
+            />
+          </div>
+          <button type="button" className="admin-link-button" onClick={() => load(page)} disabled={loading}>
+            {loading ? 'Loading…' : 'Refresh'}
           </button>
         </div>
       </div>
 
-      {error && <p className="upload-history-error">{error}</p>}
+      {error && <p className="upload-history-error" role="alert">{error}</p>}
 
-      <table className="upload-history-table">
-        <thead>
-          <tr>
-            <th>Time</th>
-            <th>Source</th>
-            <th>File</th>
-            <th>Status</th>
-            <th>Accepted / Skipped / Rejected</th>
-            <th aria-label="Actions" />
-          </tr>
-        </thead>
-        <tbody>
-          {entries.length === 0 && !loading && (
-            <tr><td colSpan={6} style={{ textAlign: 'center', padding: 16 }}>No upload history yet.</td></tr>
-          )}
-          {entries.map((e) => (
-            <React.Fragment key={e.uploadId}>
-              <tr>
-                <td>{formatDate(e.uploadedAt)}</td>
-                <td>{SOURCE_LABELS[e.source] || e.source}</td>
-                <td>{e.filename || '—'}</td>
-                <td>
-                  <span style={{ color: STATUS_COLORS[e.status] || '#000', fontWeight: 600 }}>
-                    {e.status}
-                  </span>
-                </td>
-                <td>{e.acceptedRows} / {e.skippedRows} / {e.rejectedRows}</td>
-                <td>
-                  <button type="button" onClick={() => toggleDetail(e.uploadId)}>
-                    {expandedId === e.uploadId ? 'Hide' : 'Details'}
-                  </button>
-                </td>
-              </tr>
-              {expandedId === e.uploadId && (
+      {entries.length === 0 && !loading ? (
+        <p className="upload-history-empty">No uploads recorded yet.</p>
+      ) : (
+        <table className="upload-history-table">
+          <caption className="visually-hidden">Recent CSV uploads with accepted, skipped, and rejected row counts.</caption>
+          <thead>
+            <tr>
+              <th scope="col">Time</th>
+              <th scope="col">Source</th>
+              <th scope="col">File</th>
+              <th scope="col">Status</th>
+              <th scope="col" className="count-col">Accepted</th>
+              <th scope="col" className="count-col">Skipped</th>
+              <th scope="col" className="count-col">Rejected</th>
+              <th scope="col"><span className="visually-hidden">Actions</span></th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.map((e) => (
+              <React.Fragment key={e.uploadId}>
                 <tr>
-                  <td colSpan={6} className="upload-history-detail">
-                    {!expandedDetail && <p>Loading…</p>}
-                    {expandedDetail?.error && <p className="upload-history-error">{expandedDetail.error}</p>}
-                    {expandedDetail && !expandedDetail.error && (
-                      <div>
-                        {expandedDetail.errorMessage && (
-                          <p><strong>Error:</strong> {expandedDetail.errorMessage}</p>
-                        )}
-                        {expandedDetail.rejected?.length > 0 && (
-                          <details open>
-                            <summary><strong>{expandedDetail.rejected.length} rejected</strong></summary>
-                            <ul>
-                              {expandedDetail.rejected.slice(0, 200).map((r) => (
-                                <li key={`${r.identifier}-${r.reason}-${r.field || ''}-${r.rowNumber}`}>{r.identifier} — {r.reason}{r.field ? ` (${r.field})` : ''}</li>
-                              ))}
-                              {expandedDetail.rejected.length > 200 && <li key="more-rejected">… and {expandedDetail.rejected.length - 200} more</li>}
-                            </ul>
-                          </details>
-                        )}
-                        {expandedDetail.skipped?.length > 0 && (
-                          <details>
-                            <summary>{expandedDetail.skipped.length} skipped</summary>
-                            <ul>
-                              {expandedDetail.skipped.slice(0, 200).map((r) => (
-                                <li key={`${r.identifier}-${r.reason}-${r.rowNumber}`}>{r.identifier} — {r.reason}</li>
-                              ))}
-                              {expandedDetail.skipped.length > 200 && <li key="more-skipped">… and {expandedDetail.skipped.length - 200} more</li>}
-                            </ul>
-                          </details>
-                        )}
-                      </div>
-                    )}
+                  <td data-label="Time">{formatDate(e.uploadedAt)}</td>
+                  <td data-label="Source">{SOURCE_LABELS[e.source] || e.source}</td>
+                  <td data-label="File">{e.filename || '—'}</td>
+                  <td data-label="Status">
+                    <span className={`status-badge status-badge--${e.status}`}>
+                      {STATUS_LABELS[e.status] || e.status}
+                    </span>
+                  </td>
+                  <td data-label="Accepted" className="count-col">
+                    <span className="count count--accepted">{e.acceptedRows}</span>
+                  </td>
+                  <td data-label="Skipped" className="count-col">
+                    <span className={`count ${e.skippedRows > 0 ? 'count--skipped' : 'count--zero'}`}>{e.skippedRows}</span>
+                  </td>
+                  <td data-label="Rejected" className="count-col">
+                    <span className={`count ${e.rejectedRows > 0 ? 'count--rejected' : 'count--zero'}`}>{e.rejectedRows}</span>
+                  </td>
+                  <td data-label="Details" className="upload-history-actions">
+                    <button
+                      type="button"
+                      className="upload-history-details"
+                      onClick={() => toggleDetail(e.uploadId)}
+                      aria-expanded={expandedId === e.uploadId}
+                    >
+                      <span>{expandedId === e.uploadId ? 'Hide' : 'Details'}</span>
+                      <span className="chevron" aria-hidden="true" />
+                    </button>
                   </td>
                 </tr>
-              )}
-            </React.Fragment>
-          ))}
-        </tbody>
-      </table>
+                {expandedId === e.uploadId && (
+                  <tr>
+                    <td colSpan={8} className="upload-history-detail">
+                      {!expandedDetail && <p>Loading…</p>}
+                      {expandedDetail?.error && <p className="upload-history-error" role="alert">{expandedDetail.error}</p>}
+                      {expandedDetail && !expandedDetail.error && (
+                        <div>
+                          {expandedDetail.errorMessage && (
+                            <p><strong>Error:</strong> {expandedDetail.errorMessage}</p>
+                          )}
+                          {expandedDetail.rejected?.length > 0 && (
+                            <details open>
+                              <summary>{expandedDetail.rejected.length} rejected — action needed</summary>
+                              <ul>
+                                {expandedDetail.rejected.slice(0, 200).map((r) => (
+                                  <li key={`${r.identifier}-${r.reason}-${r.field || ''}-${r.rowNumber}`}>{r.identifier} — {r.reason}{r.field ? ` (${r.field})` : ''}</li>
+                                ))}
+                                {expandedDetail.rejected.length > 200 && <li key="more-rejected">… and {expandedDetail.rejected.length - 200} more</li>}
+                              </ul>
+                            </details>
+                          )}
+                          {expandedDetail.skipped?.length > 0 && (
+                            <details>
+                              <summary>{expandedDetail.skipped.length} skipped — informational</summary>
+                              <ul>
+                                {expandedDetail.skipped.slice(0, 200).map((r) => (
+                                  <li key={`${r.identifier}-${r.reason}-${r.rowNumber}`}>{r.identifier} — {r.reason}</li>
+                                ))}
+                                {expandedDetail.skipped.length > 200 && <li key="more-skipped">… and {expandedDetail.skipped.length - 200} more</li>}
+                              </ul>
+                            </details>
+                          )}
+                          {!expandedDetail.errorMessage
+                            && !expandedDetail.rejected?.length
+                            && !expandedDetail.skipped?.length && (
+                            <p>All rows accepted — nothing skipped or rejected.</p>
+                          )}
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {pagination && pagination.totalPages > 1 && (
+        <div className="upload-history-pagination">
+          <button
+            type="button"
+            className="admin-link-button"
+            onClick={() => load(page - 1)}
+            disabled={loading || page <= 1}
+          >
+            Previous
+          </button>
+          <span className="upload-history-page-info">
+            Page {pagination.page} of {pagination.totalPages}
+          </span>
+          <button
+            type="button"
+            className="admin-link-button"
+            onClick={() => load(page + 1)}
+            disabled={loading || page >= pagination.totalPages}
+          >
+            Next
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/screens/admin/components/upload-history/component.js
+++ b/src/screens/admin/components/upload-history/component.js
@@ -12,6 +12,7 @@ const SOURCE_LABELS = {
 };
 
 const STATUS_LABELS = {
+  processing: 'Processing',
   success: 'Success',
   partial: 'Partial',
   failed: 'Failed',
@@ -164,7 +165,12 @@ const UploadHistory = ({ refreshKey }) => {
                           )}
                           {expandedDetail.rejected?.length > 0 && (
                             <details open>
-                              <summary>{expandedDetail.rejected.length} rejected — action needed</summary>
+                              <summary>{expandedDetail.rejectedRows || expandedDetail.rejected.length} rejected — action needed</summary>
+                              {expandedDetail.truncated?.rejected && (
+                                <p className="upload-history-truncated-note">
+                                  Showing first {expandedDetail.rejected.length} of {expandedDetail.rejectedRows} — older entries truncated to keep the audit doc small.
+                                </p>
+                              )}
                               <ul>
                                 {expandedDetail.rejected.slice(0, 200).map((r) => (
                                   <li key={`${r.identifier}-${r.reason}-${r.field || ''}-${r.rowNumber}`}>{r.identifier} — {r.reason}{r.field ? ` (${r.field})` : ''}</li>
@@ -175,7 +181,12 @@ const UploadHistory = ({ refreshKey }) => {
                           )}
                           {expandedDetail.skipped?.length > 0 && (
                             <details>
-                              <summary>{expandedDetail.skipped.length} skipped — informational</summary>
+                              <summary>{expandedDetail.skippedRows || expandedDetail.skipped.length} skipped — informational</summary>
+                              {expandedDetail.truncated?.skipped && (
+                                <p className="upload-history-truncated-note">
+                                  Showing first {expandedDetail.skipped.length} of {expandedDetail.skippedRows} — older entries truncated to keep the audit doc small.
+                                </p>
+                              )}
                               <ul>
                                 {expandedDetail.skipped.slice(0, 200).map((r) => (
                                   <li key={`${r.identifier}-${r.reason}-${r.rowNumber}`}>{r.identifier} — {r.reason}</li>

--- a/src/screens/admin/components/upload-history/component.js
+++ b/src/screens/admin/components/upload-history/component.js
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react';
+
+import { getUploadHistory, getUploadAudit } from '../../../../services/admin';
+
+const SOURCE_LABELS = {
+  survey123: 'Survey123',
+  'summarized-county': 'County',
+  'summarized-county-spots': 'County Spots',
+  'summarized-rangerdistrict': 'Ranger District',
+  'summarized-rangerdistrict-spots': 'Ranger District Spots',
+};
+
+const STATUS_COLORS = {
+  success: '#198754',
+  partial: '#fd7e14',
+  failed: '#dc3545',
+};
+
+const formatDate = (iso) => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return d.toLocaleString();
+};
+
+const UploadHistory = () => {
+  const [entries, setEntries] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+  const [statusFilter, setStatusFilter] = useState('');
+  const [expandedId, setExpandedId] = useState(null);
+  const [expandedDetail, setExpandedDetail] = useState(null);
+
+  const load = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const result = await getUploadHistory({ limit: 50, status: statusFilter || undefined });
+      setEntries(result?.data || []);
+    } catch (err) {
+      setError(err?.response?.data?.error?.toString() || 'Failed to load upload history');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter]);
+
+  const toggleDetail = async (uploadId) => {
+    if (expandedId === uploadId) {
+      setExpandedId(null);
+      setExpandedDetail(null);
+      return;
+    }
+    setExpandedId(uploadId);
+    setExpandedDetail(null);
+    try {
+      const detail = await getUploadAudit(uploadId);
+      setExpandedDetail(detail);
+    } catch (err) {
+      setExpandedDetail({ error: err?.response?.data?.error?.toString() || 'Failed to load detail' });
+    }
+  };
+
+  return (
+    <div id="upload-history-container">
+      <div className="upload-history-header">
+        <h3>Upload History</h3>
+        <div>
+          <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value)}>
+            <option value="">All</option>
+            <option value="success">Success</option>
+            <option value="partial">Partial</option>
+            <option value="failed">Failed</option>
+          </select>
+          <button type="button" onClick={load} disabled={loading} style={{ marginLeft: 8 }}>
+            {loading ? '...' : 'Refresh'}
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="upload-history-error">{error}</p>}
+
+      <table className="upload-history-table">
+        <thead>
+          <tr>
+            <th>Time</th>
+            <th>Source</th>
+            <th>File</th>
+            <th>Status</th>
+            <th>Accepted / Skipped / Rejected</th>
+            <th aria-label="Actions" />
+          </tr>
+        </thead>
+        <tbody>
+          {entries.length === 0 && !loading && (
+            <tr><td colSpan={6} style={{ textAlign: 'center', padding: 16 }}>No upload history yet.</td></tr>
+          )}
+          {entries.map((e) => (
+            <React.Fragment key={e.uploadId}>
+              <tr>
+                <td>{formatDate(e.uploadedAt)}</td>
+                <td>{SOURCE_LABELS[e.source] || e.source}</td>
+                <td>{e.filename || '—'}</td>
+                <td>
+                  <span style={{ color: STATUS_COLORS[e.status] || '#000', fontWeight: 600 }}>
+                    {e.status}
+                  </span>
+                </td>
+                <td>{e.acceptedRows} / {e.skippedRows} / {e.rejectedRows}</td>
+                <td>
+                  <button type="button" onClick={() => toggleDetail(e.uploadId)}>
+                    {expandedId === e.uploadId ? 'Hide' : 'Details'}
+                  </button>
+                </td>
+              </tr>
+              {expandedId === e.uploadId && (
+                <tr>
+                  <td colSpan={6} className="upload-history-detail">
+                    {!expandedDetail && <p>Loading…</p>}
+                    {expandedDetail?.error && <p className="upload-history-error">{expandedDetail.error}</p>}
+                    {expandedDetail && !expandedDetail.error && (
+                      <div>
+                        {expandedDetail.errorMessage && (
+                          <p><strong>Error:</strong> {expandedDetail.errorMessage}</p>
+                        )}
+                        {expandedDetail.rejected?.length > 0 && (
+                          <details open>
+                            <summary><strong>{expandedDetail.rejected.length} rejected</strong></summary>
+                            <ul>
+                              {expandedDetail.rejected.slice(0, 200).map((r) => (
+                                <li key={`${r.identifier}-${r.reason}-${r.field || ''}-${r.rowNumber}`}>{r.identifier} — {r.reason}{r.field ? ` (${r.field})` : ''}</li>
+                              ))}
+                              {expandedDetail.rejected.length > 200 && <li key="more-rejected">… and {expandedDetail.rejected.length - 200} more</li>}
+                            </ul>
+                          </details>
+                        )}
+                        {expandedDetail.skipped?.length > 0 && (
+                          <details>
+                            <summary>{expandedDetail.skipped.length} skipped</summary>
+                            <ul>
+                              {expandedDetail.skipped.slice(0, 200).map((r) => (
+                                <li key={`${r.identifier}-${r.reason}-${r.rowNumber}`}>{r.identifier} — {r.reason}</li>
+                              ))}
+                              {expandedDetail.skipped.length > 200 && <li key="more-skipped">… and {expandedDetail.skipped.length - 200} more</li>}
+                            </ul>
+                          </details>
+                        )}
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              )}
+            </React.Fragment>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default UploadHistory;

--- a/src/screens/admin/components/upload-history/index.js
+++ b/src/screens/admin/components/upload-history/index.js
@@ -1,0 +1,3 @@
+import UploadHistory from './component';
+
+export default UploadHistory;

--- a/src/screens/admin/components/users/component.js
+++ b/src/screens/admin/components/users/component.js
@@ -27,7 +27,7 @@ const Users = ({ users, setUsers, activeUser }) => {
 
   return (
     <>
-      <p id="users-title">Users</p>
+      <h3 id="users-title">Existing users</h3>
       {users.map((user) => {
         const isActiveUser = activeUser.email === user.email;
         return (

--- a/src/screens/admin/components/users/style.scss
+++ b/src/screens/admin/components/users/style.scss
@@ -2,45 +2,43 @@
 @import '../../../../styles/colors';
 
 #users-container {
-    overflow: auto;
-
     #users-title {
-        font-size: 1.125rem;
+        font-size: 1rem;
         font-weight: 600;
-        color: $greyBlue900;
+        color: $greyBlue800;
+        margin: 0 0 0.875rem;
 
         @media (max-width: $mobile) {
-            font-size: 1rem;
+            font-size: 0.9375rem;
         }
     }
 
     #user-info-container {
-        margin-top: 0.875rem;
-        padding: 1.0625rem 1.375rem;
-        border-radius: 12px;
-        box-shadow: 0 12px 40px 0 rgba(0, 0, 0, 0.04);
-        background-color: $white;
-        overflow: auto;
+        padding: 0.875rem 0;
+        border-bottom: 1px solid $greyBlue200;
         display: flex;
         justify-content: space-between;
         align-items: center;
         gap: 1rem;
 
         @media (max-width: $mobile) {
-            margin-top: 0.625rem;
-            padding: 0.625rem 0.75rem;
-            border-radius: 8px;
+            padding: 0.75rem 0;
             flex-direction: column;
             align-items: flex-start;
-            gap: 0.75rem;
+            gap: 0.5rem;
+        }
+
+        #user-name {
+            margin: 0;
+            font-weight: 600;
         }
 
         #user-email {
-            color: $greyBlue800;
+            color: $greyBlue700;
             font-size: 0.875rem;
             line-height: 1.51;
             word-break: break-word;
-            flex: 1;
+            margin: 0.125rem 0 0;
 
             @media (max-width: $mobile) {
                 font-size: 0.8125rem;

--- a/src/screens/admin/style.scss
+++ b/src/screens/admin/style.scss
@@ -384,3 +384,75 @@
         }
     }
 }
+
+
+.upload-history-section {
+    width: 100%;
+    max-width: 1100px;
+    margin: 24px auto;
+    padding: 16px;
+    background: $cleanWhite;
+    border-radius: 8px;
+}
+
+#upload-history-container {
+    h3 {
+        margin: 0 0 12px;
+    }
+
+    .upload-history-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        margin-bottom: 12px;
+
+        select, button {
+            padding: 4px 8px;
+            border-radius: 4px;
+            border: 1px solid $greyBlue400;
+            background: $white;
+            cursor: pointer;
+        }
+    }
+
+    .upload-history-error {
+        color: #dc3545;
+    }
+
+    .upload-history-table {
+        width: 100%;
+        border-collapse: collapse;
+        font-size: 14px;
+
+        th, td {
+            text-align: left;
+            padding: 6px 8px;
+            border-bottom: 1px solid $greyBlue300;
+            vertical-align: top;
+        }
+
+        th {
+            background: $greyBlue200;
+            font-weight: 600;
+        }
+
+        button {
+            padding: 2px 8px;
+            border-radius: 4px;
+            border: 1px solid $greyBlue400;
+            background: $white;
+            cursor: pointer;
+        }
+    }
+
+    .upload-history-detail {
+        background: $greyBlue100;
+        font-size: 13px;
+
+        ul {
+            max-height: 240px;
+            overflow-y: auto;
+            font-family: 'Menlo', 'Monaco', monospace;
+        }
+    }
+}

--- a/src/screens/admin/style.scss
+++ b/src/screens/admin/style.scss
@@ -12,14 +12,15 @@
     width: 100%;
     max-width: 64rem;
     margin: 0 auto;
+    // top padding must clear the fixed site header (~4.5rem tall + breathing room)
     padding: 7.5rem 1.5rem 4rem;
 
     @media (max-width: $tablet) {
-        padding: 5.5rem 1rem 3rem;
+        padding: 6.5rem 1rem 3rem;
     }
 
     @media (max-width: $mobile) {
-        padding: 4rem 0.75rem 2rem;
+        padding: 6.5rem 0.75rem 2rem;
     }
 }
 

--- a/src/screens/admin/style.scss
+++ b/src/screens/admin/style.scss
@@ -1,458 +1,606 @@
 @import '../../styles/breakpoints';
 @import '../../styles/colors';
 
-    #auth-container {
+// =========================================================================
+// Admin dashboard — single-page card grid.
+// The page is the only scroll container: no fixed heights, no nested overflow.
+// =========================================================================
+
+#auth-container {
     display: flex;
     flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
     width: 100%;
-    padding: 0;
-
-    h1 {
-        margin-top: 11.875rem;
-        margin-bottom: 0.625rem;
-        font-size: 2rem;
-        text-align: center;
-
-        @media (max-width: $tablet) {
-            margin-top: 7.5rem;
-            font-size: 1.75rem;
-        }
-
-        @media (max-width: $mobile) {
-            margin-top: 3.75rem;
-            margin-bottom: 0.75rem;
-            font-size: 1.5rem;
-            padding: 0 0.5rem;
-        }
-    }
-
-    #auth-header {
-        text-align: center;
-        width: 100%;
-        max-width: 800px;
-        padding: 0 1rem;
-
-        @media (max-width: $mobile) {
-            padding: 0 0.5rem;
-        }
-
-        p {
-            font-size: 1rem;
-            text-align: center;
-            color: $greyBlue800;
-            margin: 0.5rem 0;
-
-            @media (max-width: $mobile) {
-                font-size: 0.875rem;
-                margin: 0.375rem 0;
-                line-height: 1.5;
-            }
-        }
-
-        #header-options {
-            display: flex;
-            margin-top: 0.625rem;
-            justify-content: center;
-            flex-wrap: wrap;
-            gap: 1rem;
-
-            @media (max-width: $mobile) {
-                flex-direction: column;
-                gap: 0.625rem;
-                margin-top: 0.75rem;
-            }
-
-            p {
-                color: $greyBlue900;
-                text-decoration: underline;
-            }
-
-            p:hover {
-                cursor: pointer;
-            }
-
-            #sign-out {
-                margin-right: 1.875rem;
-
-                @media (max-width: $mobile) {
-                    margin-right: 0;
-                }
-            }
-        }
-    }
-
-    #dashboard-container {
-        max-width: 87.5rem;
-        margin: 0.9375rem auto 6.25rem auto;
-        padding: 0;
-        border-radius: 26px;
-        box-shadow: 0 35px 90px -10px rgba(0, 0, 0, 0.06);
-        background-color: $white;
-        width: 100%;
-
-        @media (max-width: $tablet) {
-            margin: 0.9375rem auto 3.75rem auto;
-            border-radius: 20px;
-        }
-
-        @media (max-width: $mobile) {
-            margin: 0.5rem auto 2rem auto;
-            border-radius: 12px;
-        }
-
-        #dashboard {
-            display: flex;
-            height: 85vh;
-
-            @media (max-width: $tablet) {
-                flex-direction: column;
-                height: auto;
-                gap: 1.5rem;
-            }
-
-            @media (max-width: $mobile) {
-                gap: 1rem;
-            }
-
-            #upload-container {
-                flex: 1 1 auto;
-                display: flex;
-                flex-direction: column;
-                justify-content: space-between;
-                overflow: auto;
-
-                @media (max-width: $tablet) {
-                    overflow: visible;
-                }
-
-                div {
-                    padding: 1.4375rem;
-                    border-radius: 22px;
-                    background-color: $greyBlue100;
-                    flex: 1 1 auto;
-
-                    @media (max-width: $tablet) {
-                        padding: 1.125rem;
-                        border-radius: 16px;
-                    }
-
-                    @media (max-width: $mobile) {
-                        padding: 0.875rem;
-                        border-radius: 10px;
-                    }
-                }
-
-                *+* {
-                    margin-top: 0.9375rem;
-
-                    @media (max-width: $mobile) {
-                        margin-top: 0.625rem;
-                    }
-                }
-            }
-
-            #user-container {
-                flex: 1 1 auto;
-                display: flex;
-                flex-direction: column;
-                justify-content: space-between;
-                overflow: auto;
-                margin-left: 1.25rem;
-
-                @media (max-width: $tablet) {
-                    margin-left: 0;
-                    overflow: visible;
-                }
-
-                #users-container {
-                    min-height: 10.625rem;
-
-                    @media (max-width: $tablet) {
-                        min-height: auto;
-                    }
-                }
-
-                #users-container,
-                #add-users {
-                    flex: 1 1 auto;
-                    padding: 1.4375rem;
-                    border-radius: 22px;
-                    background-color: $greyBlue100;
-
-                    @media (max-width: $tablet) {
-                        padding: 1.125rem;
-                        border-radius: 16px;
-                    }
-
-                    @media (max-width: $mobile) {
-                        padding: 0.875rem;
-                        border-radius: 10px;
-                    }
-                }
-
-                #add-users {
-                    margin-top: 0.9375rem;
-
-                    @media (max-width: $mobile) {
-                        margin-top: 0.625rem;
-                    }
-                }
-            }
-        }
-
-        .dashboard-buttons-container {
-            display: flex;
-            justify-content: space-around;
-            margin: 2.5rem;
-            flex-wrap: wrap;
-            gap: 1rem;
-
-            @media (max-width: $tablet) {
-                margin: 1.875rem 1.25rem;
-                flex-direction: column;
-                align-items: center;
-            }
-
-            @media (max-width: $mobile) {
-                margin: 1rem 0.5rem;
-                gap: 0.875rem;
-            }
-
-            .button {
-                flex: 0;
-                display: flex;
-                flex-direction: column;
-                align-items: center;
-
-                @media (max-width: $tablet) {
-                    width: 100%;
-                    max-width: 25rem;
-                }
-            }
-
-            #rerun-button,
-            #update-histogram-button {
-                margin: 1.25rem 2.5rem;
-                padding: 0.5rem 2.125rem 0.4375rem 2.1875rem;
-                border-radius: 6px;
-                background-color: $greyBlue900;
-                font-size: 1.125rem;
-                font-weight: 600;
-                line-height: 1.8;
-                color: $white;
-                white-space: nowrap;
-
-                @media (max-width: $tablet) {
-                    margin: 0;
-                    width: 100%;
-                    padding: 0.625rem 1.5rem;
-                    font-size: 1rem;
-                }
-
-                @media (max-width: $mobile) {
-                    padding: 0.5rem 1.25rem;
-                    font-size: 0.875rem;
-                }
-            }
-
-            #model-error-container,
-            #histogram-error-container {
-                color: $red500;
-                display: flex;
-                justify-content: center;
-                font-weight: 700;
-                margin-top: 0.5rem;
-                text-align: center;
-                width: 100%;
-
-                @media (max-width: $mobile) {
-                    font-size: 0.8125rem;
-                    flex-direction: column;
-                    align-items: center;
-                    margin-top: 0.625rem;
-                    padding: 0 0.5rem;
-                }
-
-                .error-mark {
-                    width: 1.875rem;
-                    height: 1.875rem;
-                    display: flex;
-                    align-items: center;
-                    justify-content: center;
-                    border-radius: 100%;
-                    flex: 0 0 auto;
-                    background-color: $red500;
-                    color: $white;
-                    margin-right: 0.625rem;
-
-                    @media (max-width: $mobile) {
-                        width: 1.375rem;
-                        height: 1.375rem;
-                        margin-right: 0;
-                        margin-bottom: 0.375rem;
-                    }
-                }
-
-                p {
-                    @media (max-width: $mobile) {
-                        margin: 0;
-                        line-height: 1.4;
-                    }
-                }
-            }
-        }
-
-    }
-}
-
-.blog-container {
-    display: flex;
-    gap: 3rem;
-    margin-top: 2rem;
+    max-width: 64rem;
+    margin: 0 auto;
+    padding: 7.5rem 1.5rem 4rem;
 
     @media (max-width: $tablet) {
-        flex-direction: column;
-        gap: 2rem;
-        margin-top: 1.5rem;
+        padding: 5.5rem 1rem 3rem;
     }
 
     @media (max-width: $mobile) {
-        gap: 1.25rem;
-        margin-top: 1rem;
+        padding: 4rem 0.75rem 2rem;
     }
+}
+
+// ---- Global focus visibility (WCAG 2.4.7) ----
+#auth-container :focus-visible {
+    outline: 3px solid $blue800;
+    outline-offset: 2px;
+    border-radius: 4px;
+}
+
+// ---- Screen-reader-only utility ----
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+// ---- Top bar ----
+.admin-topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+
+    h1 {
+        font-size: 1.875rem;
+        margin: 0;
+
+        @media (max-width: $mobile) {
+            font-size: 1.5rem;
+        }
+    }
+
+    .admin-greeting {
+        margin: 0.25rem 0 0;
+        color: $greyBlue700;
+        font-size: 1rem;
+    }
+}
+
+.admin-topbar-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+}
+
+.admin-link-button {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2.75rem; // 44px tap target (WCAG 2.5.5)
+    padding: 0.5rem 0.875rem;
+    border: 1px solid $greyBlue400;
+    border-radius: 8px;
+    background: $white;
+    color: $greyBlue900;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+        background: $greyBlue100;
+        border-color: $greyBlue500;
+    }
+}
+
+// ---- Tabs (domain separation: Data / Users / Blog) ----
+.admin-tabs {
+    display: flex;
+    gap: 0.25rem;
+    border-bottom: 1px solid $greyBlue300;
+    margin-bottom: 1.5rem;
+    overflow-x: visible;
+}
+
+.admin-tab {
+    appearance: none;
+    border: none;
+    background: none;
+    padding: 0.75rem 1.25rem;
+    min-height: 2.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    color: $greyBlue700;
+    cursor: pointer;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -1px; // overlap the tablist border
+    transition: color 0.15s ease, border-color 0.15s ease;
+
+    &:hover {
+        color: $greyBlue900;
+    }
+
+    &.admin-tab--active {
+        color: $brandPrimary;
+        border-bottom-color: $brandPrimary;
+    }
+}
+
+// ---- Card stack (single column; the page is the only scroll container) ----
+.admin-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+
+    @media (max-width: $tablet) {
+        gap: 1.25rem;
+    }
+}
+
+.admin-card {
+    background: $cleanWhite;
+    border: 1px solid $greyBlue300;
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+
+    @media (max-width: $mobile) {
+        padding: 1.125rem;
+        border-radius: 12px;
+    }
+}
+
+.admin-card-head {
+    margin-bottom: 1.25rem;
+
+    h2 {
+        font-size: 1.25rem;
+        font-weight: 700;
+        line-height: 1.3;
+        color: $headingColor;
+        margin: 0;
+    }
+}
+
+// ---- Shared heading scale (keeps every card/sub-section consistent) ----
+// Card title = h2 (1.25rem / 700); sub-section title = h3 (1rem / 600).
+.admin-card .blog-posts-form-title,
+.admin-blog-stack .blog-posts-form-title,
+.admin-blog-stack .blog-posts-title {
+    font-size: 1.25rem;
+    font-weight: 700;
+    line-height: 1.3;
+    color: $headingColor;
+    margin: 0 0 1.25rem;
+    padding: 0;
+    border: none;
+}
+
+.admin-card-note {
+    margin: 0.375rem 0 0;
+    font-size: 0.875rem;
+    color: $greyBlue700;
+    line-height: 1.5;
+
+    a {
+        color: $blue800;
+        text-decoration: underline;
+    }
+}
+
+// ---- Shared primary button ----
+.admin-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.75rem;
+    padding: 0.625rem 1.5rem;
+    border: none;
+    border-radius: 8px;
+    background: $brandSecondary;
+    color: $white;
+    font-size: 1rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+
+    &:hover:not(:disabled) {
+        background: $brandPrimary;
+    }
+
+    &:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+    }
+}
+
+// ---- Pipeline actions ----
+.admin-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+}
+
+.admin-action {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+
+    @media (max-width: $mobile) {
+        width: 100%;
+
+        .admin-button {
+            width: 100%;
+        }
+    }
+}
+
+.admin-action-error {
+    margin: 0;
+    color: $statusDanger;
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+// ---- Data uploads (flat rows inside the Data Uploads card; no nested boxes) ----
+.admin-upload-list {
+    display: flex;
+    flex-direction: column;
+}
+
+// List-item padding + dividers only inside the Data Uploads list (not blog).
+.admin-upload-list .upload-item {
+    padding: 1rem 0;
+
+    & + & {
+        border-top: 1px solid $greyBlue200;
+    }
+
+    &:first-child {
+        padding-top: 0;
+    }
+}
+
+.upload-item {
+    .upload-item-name {
+        margin: 0;
+        font-weight: 600;
+    }
+
+    #file-selected {
+        margin: 0.25rem 0 0;
+        font-size: 0.875rem;
+        color: $greyBlue700;
+        white-space: normal;
+        overflow: visible;
+        overflow-wrap: anywhere;
+    }
+}
+
+.upload-item-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.upload-item-info {
+    min-width: 0;
+}
+
+.upload-item-action {
+    flex-shrink: 0;
+
+    .custom-file-upload {
+        margin-top: 0;
+    }
+}
+
+// ---- User section (flat sub-sections inside the Users card; no nested boxes) ----
+#user-container {
+    display: flex;
+    flex-direction: column;
+}
+
+#add-users {
+    margin-top: 1.25rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid $greyBlue200;
+}
+
+// ---- Blog (the two containers ARE the cards — stacked full width) ----
+// Note: scoped name to avoid clashing with the public blog page's global
+// `.blog-container` (which adds 0 10rem padding).
+.admin-blog-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
 }
 
 .add-blog-post-container,
 .blog-posts-container {
-    flex: 1 1 auto;
-    padding: 2rem;
-    border-radius: 1.375rem;
-    background-color: $greyBlue100;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
-    border: 1px solid $greyBlue300;
-    margin-top: 2rem;
-
-    @media (max-width: $tablet) {
-        width: 100%;
-        padding: 1.5rem;
-        margin-top: 0;
-        border-radius: 1rem;
-    }
-
-    @media (max-width: $mobile) {
-        padding: 1rem;
-        border-radius: 0.625rem;
-    }
-}
-
-.blog-posts-container {
-    overflow-y: auto;
-    max-height: 37.5rem;
-    min-height: 25rem;
-
-    @media (max-width: $tablet) {
-        margin-left: 0;
-        max-height: none;
-        min-height: auto;
-    }
-
-    @media (max-width: $mobile) {
-        max-height: 31.25rem;
-    }
-
-    &::-webkit-scrollbar {
-        width: 8px;
-
-        @media (max-width: $mobile) {
-            width: 6px;
-        }
-    }
-
-    &::-webkit-scrollbar-track {
-        background: $greyBlue200;
-        border-radius: 4px;
-    }
-
-    &::-webkit-scrollbar-thumb {
-        background: $greyBlue400;
-        border-radius: 4px;
-
-        &:hover {
-            background: $greyBlue500;
-        }
-    }
-}
-
-
-.upload-history-section {
     width: 100%;
-    max-width: 1100px;
-    margin: 24px auto;
-    padding: 16px;
+    box-sizing: border-box;
+    padding: 1.5rem;
+    border-radius: 16px;
     background: $cleanWhite;
-    border-radius: 8px;
+    border: 1px solid $greyBlue300;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.04);
+
+    @media (max-width: $mobile) {
+        padding: 1.125rem;
+        border-radius: 12px;
+    }
 }
 
+// ---- Upload history ----
 #upload-history-container {
-    h3 {
-        margin: 0 0 12px;
-    }
-
-    .upload-history-header {
+    .upload-history-toolbar {
         display: flex;
         justify-content: space-between;
         align-items: center;
-        margin-bottom: 12px;
+        gap: 1rem;
+        margin-bottom: 1rem;
+        flex-wrap: wrap;
+    }
 
-        select, button {
-            padding: 4px 8px;
-            border-radius: 4px;
-            border: 1px solid $greyBlue400;
-            background: $white;
-            cursor: pointer;
+    .upload-history-intro {
+        margin: 0;
+        font-size: 0.875rem;
+        color: $greyBlue700;
+        flex: 1 1 16rem;
+    }
+
+    .upload-history-controls {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        flex-wrap: wrap;
+    }
+
+    .upload-history-filter {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        font-size: 0.875rem;
+
+        .upload-history-filter-label {
+            color: $greyBlue700;
+        }
+
+        .choice-input-wrapper {
+            min-width: 9rem;
         }
     }
 
     .upload-history-error {
-        color: #dc3545;
+        color: $statusDanger;
+        font-weight: 600;
     }
 
-    .upload-history-table {
-        width: 100%;
-        border-collapse: collapse;
-        font-size: 14px;
+    .upload-history-empty {
+        padding: 1.5rem;
+        text-align: center;
+        color: $greyBlue700;
+    }
+}
 
-        th, td {
-            text-align: left;
-            padding: 6px 8px;
-            border-bottom: 1px solid $greyBlue300;
-            vertical-align: top;
-        }
+// Keep the timestamp on one line.
+.upload-history-table {
+    th:first-child,
+    td:first-child {
+        white-space: nowrap;
+    }
+}
 
-        th {
-            background: $greyBlue200;
-            font-weight: 600;
-        }
-
-        button {
-            padding: 2px 8px;
-            border-radius: 4px;
-            border: 1px solid $greyBlue400;
-            background: $white;
-            cursor: pointer;
-        }
+// Numeric count columns (Accepted / Skipped / Rejected) — header and value
+// both centered so each number sits directly under its name.
+.upload-history-table {
+    .count-col {
+        text-align: center;
+        width: 5.5rem;
     }
 
+    .count {
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .count--accepted { color: $statusSuccess; }
+    .count--skipped { color: $statusWarning; }
+    .count--rejected { color: $statusDanger; }
+    .count--zero { color: $greyBlue500; }
+}
+
+// On the mobile stacked layout, align values to the right next to their
+// data-label (consistent with the other stacked cells).
+@media (max-width: $tablet) {
+    .upload-history-table .count-col {
+        text-align: right;
+        width: auto;
+    }
+}
+
+// Details row action — light ghost button with an expand chevron.
+.upload-history-actions {
+    text-align: right;
+    white-space: nowrap;
+}
+
+.upload-history-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 1rem;
+    margin-top: 1rem;
+    flex-wrap: wrap;
+}
+
+.upload-history-page-info {
+    font-size: 0.875rem;
+    color: $greyBlue700;
+}
+
+.upload-history-details {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.25rem 0.25rem;
+    border: none;
+    background: none;
+    color: $greyBlue800;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: color 0.15s ease;
+
+    &:hover {
+        color: $greyBlue900;
+        text-decoration: underline;
+    }
+
+    .chevron {
+        width: 0;
+        height: 0;
+        border-left: 4px solid transparent;
+        border-right: 4px solid transparent;
+        border-top: 5px solid currentColor;
+        transition: transform 0.15s ease;
+    }
+
+    &[aria-expanded='true'] .chevron {
+        transform: rotate(180deg);
+    }
+}
+
+.upload-history-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+
+    caption {
+        text-align: left;
+        margin-bottom: 0.5rem;
+        color: $greyBlue700;
+        font-size: 0.8125rem;
+    }
+
+    th,
+    td {
+        text-align: left;
+        padding: 0.625rem 0.75rem;
+        border-bottom: 1px solid $greyBlue300;
+        vertical-align: middle;
+    }
+
+    // expanded details block stays top-aligned for its multi-line content
     .upload-history-detail {
-        background: $greyBlue100;
-        font-size: 13px;
+        vertical-align: top;
+    }
 
-        ul {
-            max-height: 240px;
-            overflow-y: auto;
-            font-family: 'Menlo', 'Monaco', monospace;
+    thead th {
+        background: $greyBlue200;
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    tbody tr:hover {
+        background: $greyBlue100;
+    }
+
+    // Responsive: stack each row into a labelled block on narrow screens —
+    // avoids horizontal scrolling inside the card.
+    @media (max-width: $tablet) {
+        thead {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
         }
+
+        tbody tr {
+            display: block;
+            margin-bottom: 0.75rem;
+            border: 1px solid $greyBlue300;
+            border-radius: 10px;
+            padding: 0.5rem 0.75rem;
+        }
+
+        td {
+            display: flex;
+            justify-content: space-between;
+            gap: 1rem;
+            padding: 0.375rem 0;
+            border-bottom: none;
+            text-align: right;
+
+            &::before {
+                content: attr(data-label);
+                font-weight: 600;
+                text-align: left;
+                color: $greyBlue700;
+            }
+        }
+    }
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.8125rem;
+    font-weight: 600;
+
+    &::before {
+        content: '';
+        width: 0.5rem;
+        height: 0.5rem;
+        border-radius: 50%;
+        background: currentColor;
+    }
+
+    &.status-badge--success {
+        color: $statusSuccess;
+        background: $statusSuccessBg;
+    }
+
+    &.status-badge--partial {
+        color: $statusWarning;
+        background: $statusWarningBg;
+    }
+
+    &.status-badge--failed {
+        color: $statusDanger;
+        background: $statusDangerBg;
+    }
+}
+
+.upload-history-detail {
+    background: $greyBlue100;
+
+    details {
+        margin: 0.5rem 0;
+
+        summary {
+            cursor: pointer;
+            font-weight: 600;
+            padding: 0.25rem 0;
+        }
+    }
+
+    ul {
+        margin: 0.5rem 0 0;
+        padding-left: 1.25rem;
+        font-size: 0.8125rem;
+        line-height: 1.6;
     }
 }

--- a/src/screens/data-table/style.scss
+++ b/src/screens/data-table/style.scss
@@ -571,7 +571,7 @@
 
           .retry-button {
             padding: 0.75rem 1.5rem;
-            background: $brandPrimary;
+            background: $brandSecondary;
             color: $white;
             border: none;
             border-radius: 6px;
@@ -581,7 +581,7 @@
             transition: all 0.3s ease;
 
             &:hover {
-              background: darken($brandPrimary, 10%);
+              background: darken($brandSecondary, 10%);
               transform: translateY(-1px);
             }
           }

--- a/src/screens/download-data/style.scss
+++ b/src/screens/download-data/style.scss
@@ -41,7 +41,7 @@
       .resources-link-button {
         display: inline-flex;
         align-items: center;
-        background-color: $brandPrimary;
+        background-color: $brandSecondary;
         color: white;
         padding: 0.75rem 1.5rem;
         border-radius: 6px;
@@ -52,7 +52,7 @@
         border: 2px solid transparent;
 
         &:hover {
-          background-color: $brandSecondary;
+          background-color: $brandPrimary;
           transform: translateY(-1px);
           box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
         }

--- a/src/screens/resources/style.scss
+++ b/src/screens/resources/style.scss
@@ -149,7 +149,7 @@
                 .resource-link {
                     display: inline-flex;
                     align-items: center;
-                    background-color: $brandPrimary;
+                    background-color: $brandSecondary;
                     color: white;
                     padding: 0.75rem 1.5rem;
                     border-radius: 6px;
@@ -160,7 +160,7 @@
                     border: 2px solid transparent;
 
                     &:hover {
-                        background-color: $brandSecondary;
+                        background-color: $brandPrimary;
                         transform: translateY(-1px);
                         box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
                     }

--- a/src/screens/single-blog-post/style.scss
+++ b/src/screens/single-blog-post/style.scss
@@ -124,8 +124,8 @@
     }
 
     &.liked {
-        background: $brandPrimary;
-        border-color: $brandPrimary;
+        background: $brandSecondary;
+        border-color: $brandSecondary;
         color: $cleanWhite;
     }
 
@@ -337,7 +337,7 @@
 }
 
 .submit-comment-button {
-    background: $brandPrimary;
+    background: $brandSecondary;
     color: $cleanWhite;
     border: none;
     border-radius: 8px;
@@ -348,7 +348,7 @@
     transition: all 0.2s ease;
 
     &:hover {
-        background: $brandSecondary;
+        background: $brandPrimary;
         transform: translateY(-0.0625rem);
         box-shadow: 0 0.25rem 0.75rem rgba(26, 77, 46, 0.3);
     }

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -14,84 +14,62 @@ const SUBROUTES = {
   SPOT_DATA_RD: 'summarized-rangerdistrict/spots/upload',
   SURVEY123: 'survey123/upload',
   HISTOGRAM: 'histogram',
+  UPLOAD_AUDIT: 'upload-audit',
+};
+
+const postCsv = async (path, file) => {
+  const url = `${global.AUTOMATION_API_URL}/${path}`;
+  const token = getAuthTokenFromStorage();
+  const formData = new FormData();
+  formData.append('csv', file);
+  const { data: { data } } = await axios.post(url, formData, {
+    headers: {
+      authorization: `Bearer ${token}`,
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+  return data;
+};
+
+export const uploadCountySpotCsv = (file) => postCsv(SUBROUTES.SPOT_DATA_COUNTY, file);
+export const previewCountySpotCsv = (file) => postCsv(`${SUBROUTES.SPOT_DATA_COUNTY}/preview`, file);
+
+export const uploadRangerDistrictSpotCsv = (file) => postCsv(SUBROUTES.SPOT_DATA_RD, file);
+export const previewRangerDistrictSpotCsv = (file) => postCsv(`${SUBROUTES.SPOT_DATA_RD}/preview`, file);
+
+export const uploadSurvey123UnsummarizedCsv = (file) => postCsv(SUBROUTES.SURVEY123, file);
+export const previewSurvey123UnsummarizedCsv = (file) => postCsv(`${SUBROUTES.SURVEY123}/preview`, file);
+
+/**
+ * @description lists upload audit entries (paginated)
+ */
+export const getUploadHistory = async ({
+  page = 1,
+  limit = 50,
+  status,
+  source,
+} = {}) => {
+  const params = toQueryParams({
+    page, limit, status, source,
+  });
+  const url = `${global.AUTOMATION_API_URL}/${SUBROUTES.UPLOAD_AUDIT}?${params}`;
+  const token = getAuthTokenFromStorage();
+  const { data: { data } } = await axios.get(url, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  return data;
 };
 
 /**
- * @description uploads spot data county csv
- * @param {File} file csv to upload
- * @returns {Promise<Object>} API response
+ * @description fetches a single audit entry (with full skipped/rejected lists)
  */
-export const uploadCountySpotCsv = async (file) => {
-  const url = `${global.AUTOMATION_API_URL}/${SUBROUTES.SPOT_DATA_COUNTY}`;
+export const getUploadAudit = async (uploadId) => {
+  const url = `${global.AUTOMATION_API_URL}/${SUBROUTES.UPLOAD_AUDIT}/${uploadId}`;
   const token = getAuthTokenFromStorage();
-
-  const formData = new FormData();
-  formData.append('csv', file);
-
-  try {
-    const { data: { data } } = await axios.post(url, formData, {
-      headers: {
-        authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    });
-    return data;
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
-};
-
-/**
- * @description uploads spot data ranger district csv
- * @param {File} file csv to upload
- * @returns {Promise<Object>} API response
- */
-export const uploadRangerDistrictSpotCsv = async (file) => {
-  const url = `${global.AUTOMATION_API_URL}/${SUBROUTES.SPOT_DATA_RD}`;
-  const token = getAuthTokenFromStorage();
-
-  const formData = new FormData();
-  formData.append('csv', file);
-
-  try {
-    const { data: { data } } = await axios.post(url, formData, {
-      headers: {
-        authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    });
-    return data;
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
-};
-
-/**
- * @description uploads survey123 unsummarized csv
- * @param {File} file csv to upload
- * @returns {Promise<Object>} API response
- */
-export const uploadSurvey123UnsummarizedCsv = async (file) => {
-  const url = `${global.AUTOMATION_API_URL}/${SUBROUTES.SURVEY123}`;
-  const token = getAuthTokenFromStorage();
-
-  const formData = new FormData();
-  formData.append('csv', file);
-
-  try {
-    const { data: { data } } = await axios.post(url, formData, {
-      headers: {
-        authorization: `Bearer ${token}`,
-        'Content-Type': 'multipart/form-data',
-      },
-    });
-    return data;
-  } catch (error) {
-    console.log(error);
-    throw error;
-  }
+  const { data: { data } } = await axios.get(url, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  return data;
 };
 
 /**

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -37,8 +37,44 @@ export const previewCountySpotCsv = (file) => postCsv(`${SUBROUTES.SPOT_DATA_COU
 export const uploadRangerDistrictSpotCsv = (file) => postCsv(SUBROUTES.SPOT_DATA_RD, file);
 export const previewRangerDistrictSpotCsv = (file) => postCsv(`${SUBROUTES.SPOT_DATA_RD}/preview`, file);
 
-export const uploadSurvey123UnsummarizedCsv = (file) => postCsv(SUBROUTES.SURVEY123, file);
 export const previewSurvey123UnsummarizedCsv = (file) => postCsv(`${SUBROUTES.SURVEY123}/preview`, file);
+
+const sleep = (ms) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+const getSurvey123UploadStatus = async (uploadId) => {
+  const url = `${global.AUTOMATION_API_URL}/${SUBROUTES.SURVEY123}/status?uploadId=${encodeURIComponent(uploadId)}`;
+  const token = getAuthTokenFromStorage();
+  const { data: { data } } = await axios.get(url, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  return data; // { status, message, result }
+};
+
+/**
+ * @description uploads a Survey123 CSV. The endpoint returns 202 + uploadId and
+ * processes in the background, so we poll the status endpoint and only resolve
+ * once processing finishes (or reject if it failed). This keeps the UI honest
+ * ("uploading" until truly done) and lets the caller refresh history once.
+ */
+export const uploadSurvey123UnsummarizedCsv = async (file) => {
+  const { uploadId } = await postCsv(SUBROUTES.SURVEY123, file);
+  if (!uploadId) return { uploadId: null };
+
+  const intervalMs = 2000;
+  const timeoutMs = 60000;
+  const start = Date.now();
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // eslint-disable-next-line no-await-in-loop
+    const status = await getSurvey123UploadStatus(uploadId);
+    if (status?.status === 'success') return status.result || { uploadId };
+    if (status?.status === 'error') throw new Error(status.message || 'Upload failed');
+    if (Date.now() - start > timeoutMs) return { uploadId, pending: true };
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(intervalMs);
+  }
+};
 
 /**
  * @description lists upload audit entries (paginated)

--- a/src/services/admin.js
+++ b/src/services/admin.js
@@ -68,7 +68,11 @@ export const uploadSurvey123UnsummarizedCsv = async (file) => {
   while (true) {
     // eslint-disable-next-line no-await-in-loop
     const status = await getSurvey123UploadStatus(uploadId);
-    if (status?.status === 'success') return status.result || { uploadId };
+    // 'success' and 'partial' are both terminal — partial means some rows were
+    // accepted and some rejected; the caller inspects status.result for details.
+    if (status?.status === 'success' || status?.status === 'partial') {
+      return status.result || { uploadId };
+    }
     if (status?.status === 'error') throw new Error(status.message || 'Upload failed');
     if (Date.now() - start > timeoutMs) return { uploadId, pending: true };
     // eslint-disable-next-line no-await-in-loop

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -62,6 +62,15 @@ $blue400: #B4DBFF;
 $blue500: #86CCFF;
 $blue800: #2656B5;
 
+// Status / semantic (upload audit, validation, alerts)
+// Foreground colors meet WCAG AA on white and on their paired light bg.
+$statusSuccess: #146C43;
+$statusSuccessBg: #E7F4EC;
+$statusWarning: #8A4B00;
+$statusWarningBg: #FFF1DD;
+$statusDanger: #B02A1B;
+$statusDangerBg: #FBE7E4;
+
 // Typography
 $textColor: $deepCharcoal;
 $headingColor: $deepCharcoal;


### PR DESCRIPTION
# Description
Adds the admin-side CSV upload preview, upload history panel, and supporting UX changes that pair with the audit-log work on `pine-beetle-automation`. Also includes a visual refresh of the admin dashboard and small fixes to existing screens.

> Paired backend PR: `pine-beetle-automation#<PR-number>` (branch `feature/upload-preview-and-audit`). This PR depends on it being deployed first — the new endpoints (`/upload/preview`, `/upload/status`, `/upload-audit`) are consumed by this UI.

## Highlights

### New features
- **CSV upload preview** — dry-run before commit. Shows accepted / skipped / rejected counts plus per-row reasons (`MISSING_REQUIRED_FIELD`, `INVALID_NUMERIC`, `ACTIVE_DAYS_OUT_OF_RANGE`, etc.) so admins can fix the file before writing to the DB.
- **Upload history panel** — paginated audit log of every upload (county, ranger district, Survey123, and their spots variants) with status badges, source/status filters, and an expandable detail view with per-row outcomes.
- **Async Survey123 uploads** — large CSVs no longer hit the Heroku 30s request timeout. Client posts the file, receives an `uploadId`, then polls `/upload/status` until the backend reports a terminal state.

### UX polish
- Admin dashboard **redesigned** — clearer hierarchy, tabbed navigation (Data / Users / Blog), better focus styles and ARIA labels for keyboard / screen-reader users.
- **Sage-green action buttons** across the app for visual consistency.
- Login screen — Forgot Password link centered under the password field; mobile fixed-header offset cleaned up.

### Bug fixes (paired with the automation backend changes)
- `partial` upload status now treated as terminal in the polling loop — previously the client spun until the 60s timeout on partial uploads. Resolves immediately with the result.
- `processing` status now shows a friendly `Processing` badge in upload history (was raw `"processing"` text).
- Truncation note in upload history detail — when the audit list exceeds 1000 entries, the UI surfaces `"Showing first N of M — older entries truncated"` so users aren't misled by visible-vs-actual counts.
- Zero-accepted toast — no longer says `"Successfully uploaded file. 0 accepted…"` (contradictory). Now reads `"No rows accepted. N rejected — check details below."`

## Notable behaviour changes for users
- Survey123 preview `accepted` count is now **per-survey**, not per-week. A CSV of 20 surveys × 6 weeks previously showed `120 accepted`; now shows `20 accepted`. More accurate, but operators familiar with the old number should be informed.
- CSVs with **empty cells in key columns** (year / state / county / rangerDistrict) are now rejected with a clear reason instead of silently being stored with `year=0` / `state=null`. Pairs with the backend integrity fix.


## Highlights

## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

## Screenshots

Please attach any design screenshots if UI update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/pine-beetle-frontend/pr/718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782480910&installation_id=133523038&pr_number=718&repository=dali-lab%2Fpine-beetle-frontend&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fpine-beetle-frontend%2Fpull%2F718&signature=e542dcf083c220869334b896d3334b8bf27fc3c71ad0f371f6956e8ce4e20685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->