### PR TITLE
fix(legend): restore missing red color in outbreak probability legend

### DIFF
--- a/src/screens/home/components/prediction-map/constants.js
+++ b/src/screens/home/components/prediction-map/constants.js
@@ -1,8 +1,2 @@
 export const thresholds = ['0-2.5%', '2.5-5%', '5-15%', '15-25%', '25-40%', '40-100%'];
-export const colors = [
-  '#649AD3',
-  '#E6B951',
-  '#E89876',
-  '#AC5E7D',
-  '#783F58',
-];
+export { colors } from '../../../../utils/colors';


### PR DESCRIPTION
# Description

# Problem
The "Outbreak Probability" legend showed only 5 colors instead of 6 — the red
(15-25% "High") was missing and the last category "40-100% (Extreme)" rendered
as a blank box. The map itself colored correctly.

## Cause
The legend used its own duplicated `colors` array that had drifted out of sync
with the map's palette in `utils/colors.js`. The `#D95557` (red) entry was
missing, so with 5 colors for 6 thresholds every category shifted one slot and
"Extreme" was left with no color.

## Fix
Re-export `colors` from `utils/colors.js` so the legend and the map share a
single source of truth and can't drift apart again.
## Type of Change

- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [ ] Unit/integration tests
- [ ] Documentation

## Tickets

- [Issue Number](Link)

## Screenshots

Please attach any design screenshots if UI update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/pine-beetle-frontend/pr/719"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782482288&installation_id=133523038&pr_number=719&repository=dali-lab%2Fpine-beetle-frontend&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fpine-beetle-frontend%2Fpull%2F719&signature=ef076e23d4d80e439ba432157134d92729acdb8886e369565a4d6407864d87d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->