### PR TITLE
Render Fragmentation map via ArcGIS Online tile layer

### DIFF
--- a/src/components/arcgis-raster-map/component.js
+++ b/src/components/arcgis-raster-map/component.js
@@ -1,6 +1,9 @@
 import mapboxgl from 'mapbox-gl';
-import React, { useEffect, useRef } from 'react';
+import React, {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
 
+import Loader from '../loader';
 import { logError } from '../../utils/logger';
 import { MAP_STYLE_URL } from '../../utils/map';
 import { resolveArcgisTileLayer } from '../../utils/arcgis';
@@ -11,6 +14,11 @@ import './style.scss';
 const SOURCE_ID = 'arcgis-raster-source';
 const LAYER_ID = 'arcgis-raster-layer';
 
+const STATUS = { LOADING: 'loading', READY: 'ready', ERROR: 'error' };
+
+// Snippets that are clearly placeholders and should not be shown to end users.
+const PLACEHOLDER_SNIPPETS = new Set(['', 'test', 'test test']);
+
 /**
  * Renders an ArcGIS Online hosted tile layer as a mapbox-gl raster layer.
  * The layer is referenced by its portal item id and resolved to a live tile
@@ -19,14 +27,23 @@ const LAYER_ID = 'arcgis-raster-layer';
  * @param {Object} props
  * @param {string} props.itemId - ArcGIS Online portal item id (hosted tile Map Service)
  * @param {string} [props.title] - Accessible label for the map container
+ * @param {string} [props.errorMessage] - Message shown when the map cannot be loaded
  */
-const ArcgisRasterMap = ({ itemId, title = 'Map' }) => {
+const ArcgisRasterMap = ({
+  itemId,
+  title = 'Map',
+  errorMessage = 'This map is temporarily unavailable. Please try again later.',
+}) => {
   const containerRef = useRef(null);
+  const [status, setStatus] = useState(STATUS.LOADING);
+  const [meta, setMeta] = useState(null);
 
   useEffect(() => {
     if (!containerRef.current || !itemId) return undefined;
 
     mapboxgl.accessToken = process.env.MAPBOX_ACCESS_TOKEN;
+    setStatus(STATUS.LOADING);
+    setMeta(null);
 
     const map = new mapboxgl.Map({
       container: containerRef.current,
@@ -39,9 +56,26 @@ const ArcgisRasterMap = ({ itemId, title = 'Map' }) => {
 
     let cancelled = false;
 
+    // Mark the map ready once our raster source has finished its initial load.
+    // Tiles outside the layer's extent return 404 — that is expected and still
+    // leaves the source "loaded", so this fires normally.
+    const onSourceData = (e) => {
+      if (e.sourceId !== SOURCE_ID || !map.isSourceLoaded(SOURCE_ID)) return;
+      map.off('sourcedata', onSourceData);
+      if (!cancelled) setStatus(STATUS.READY);
+    };
+
     const addArcgisLayer = async () => {
       const resolved = await resolveArcgisTileLayer(itemId);
-      if (cancelled || isMapRemoved(map) || !resolved) return;
+      if (cancelled || isMapRemoved(map)) return;
+
+      if (!resolved) {
+        setStatus(STATUS.ERROR);
+        return;
+      }
+
+      setMeta(resolved);
+      map.on('sourcedata', onSourceData);
 
       if (!map.getSource(SOURCE_ID)) {
         map.addSource(SOURCE_ID, {
@@ -89,7 +123,50 @@ const ArcgisRasterMap = ({ itemId, title = 'Map' }) => {
     };
   }, [itemId]);
 
-  return <div ref={containerRef} className="arcgis-raster-map" aria-label={title} />;
+  const caption = useMemo(() => {
+    if (!meta) return null;
+
+    const parts = ['Source: ArcGIS Online (Esri)'];
+    if (meta.modified) {
+      const updated = new Date(meta.modified).toLocaleDateString('en-US', {
+        year: 'numeric', month: 'long', day: 'numeric',
+      });
+      parts.push(`Updated ${updated}`);
+    }
+
+    const description = meta.snippet && !PLACEHOLDER_SNIPPETS.has(meta.snippet.trim().toLowerCase())
+      ? meta.snippet.trim()
+      : null;
+
+    return { description, source: parts.join(' · ') };
+  }, [meta]);
+
+  return (
+    <div className="arcgis-raster-map">
+      <div className="arcgis-raster-map__frame">
+        <div ref={containerRef} className="arcgis-raster-map__canvas" aria-label={title} />
+
+        {status === STATUS.LOADING && (
+          <div className="arcgis-raster-map__overlay">
+            <Loader inline message="Loading map…" />
+          </div>
+        )}
+
+        {status === STATUS.ERROR && (
+          <div className="arcgis-raster-map__overlay arcgis-raster-map__overlay--error">
+            <p>{errorMessage}</p>
+          </div>
+        )}
+      </div>
+
+      {caption && (
+        <p className="arcgis-raster-map__caption">
+          {caption.description && <span>{caption.description} </span>}
+          <span className="arcgis-raster-map__source">{caption.source}</span>
+        </p>
+      )}
+    </div>
+  );
 };
 
 export default ArcgisRasterMap;

--- a/src/components/arcgis-raster-map/component.js
+++ b/src/components/arcgis-raster-map/component.js
@@ -1,0 +1,95 @@
+import mapboxgl from 'mapbox-gl';
+import React, { useEffect, useRef } from 'react';
+
+import { logError } from '../../utils/logger';
+import { MAP_STYLE_URL } from '../../utils/map';
+import { resolveArcgisTileLayer } from '../../utils/arcgis';
+import { isMapRemoved, markMapAsRemoved } from '../../utils/map-instance-tracker';
+
+import './style.scss';
+
+const SOURCE_ID = 'arcgis-raster-source';
+const LAYER_ID = 'arcgis-raster-layer';
+
+/**
+ * Renders an ArcGIS Online hosted tile layer as a mapbox-gl raster layer.
+ * The layer is referenced by its portal item id and resolved to a live tile
+ * service at runtime, so republishing the service in ArcGIS updates the view.
+ *
+ * @param {Object} props
+ * @param {string} props.itemId - ArcGIS Online portal item id (hosted tile Map Service)
+ * @param {string} [props.title] - Accessible label for the map container
+ */
+const ArcgisRasterMap = ({ itemId, title = 'Map' }) => {
+  const containerRef = useRef(null);
+
+  useEffect(() => {
+    if (!containerRef.current || !itemId) return undefined;
+
+    mapboxgl.accessToken = process.env.MAPBOX_ACCESS_TOKEN;
+
+    const map = new mapboxgl.Map({
+      container: containerRef.current,
+      style: MAP_STYLE_URL,
+      center: [-88, 33],
+      zoom: 4,
+    });
+
+    map.addControl(new mapboxgl.NavigationControl({ showCompass: true, showZoom: true }));
+
+    let cancelled = false;
+
+    const addArcgisLayer = async () => {
+      const resolved = await resolveArcgisTileLayer(itemId);
+      if (cancelled || isMapRemoved(map) || !resolved) return;
+
+      if (!map.getSource(SOURCE_ID)) {
+        map.addSource(SOURCE_ID, {
+          type: 'raster',
+          tiles: [resolved.tileUrl],
+          tileSize: 256,
+          attribution: 'Esri',
+        });
+      }
+
+      if (!map.getLayer(LAYER_ID)) {
+        map.addLayer({ id: LAYER_ID, type: 'raster', source: SOURCE_ID });
+      }
+
+      if (resolved.bounds) {
+        map.fitBounds(resolved.bounds, { padding: 20, duration: 0 });
+      }
+    };
+
+    // Add the layer as soon as the style is ready. We key off style readiness
+    // rather than the map's 'load' event because 'load' waits for the render
+    // loop, which browsers throttle while the tab is backgrounded — the style,
+    // and therefore our layer, would otherwise never get added.
+    if (map.isStyleLoaded()) {
+      addArcgisLayer();
+    } else {
+      const onStyleData = () => {
+        if (!map.isStyleLoaded()) return;
+        map.off('styledata', onStyleData);
+        addArcgisLayer();
+      };
+      map.on('styledata', onStyleData);
+    }
+
+    return () => {
+      cancelled = true;
+      if (map && typeof map.remove === 'function' && !isMapRemoved(map)) {
+        try {
+          markMapAsRemoved(map);
+          map.remove();
+        } catch (error) {
+          logError('Error cleaning up ArcGIS map', error, { component: 'ArcgisRasterMap' });
+        }
+      }
+    };
+  }, [itemId]);
+
+  return <div ref={containerRef} className="arcgis-raster-map" aria-label={title} />;
+};
+
+export default ArcgisRasterMap;

--- a/src/components/arcgis-raster-map/index.js
+++ b/src/components/arcgis-raster-map/index.js
@@ -1,0 +1,3 @@
+import ArcgisRasterMap from './component';
+
+export default ArcgisRasterMap;

--- a/src/components/arcgis-raster-map/style.scss
+++ b/src/components/arcgis-raster-map/style.scss
@@ -1,0 +1,5 @@
+.arcgis-raster-map {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/src/components/arcgis-raster-map/style.scss
+++ b/src/components/arcgis-raster-map/style.scss
@@ -1,5 +1,63 @@
+@import '../../styles/breakpoints';
+@import '../../styles/colors';
+
 .arcgis-raster-map {
   width: 100%;
-  height: 100%;
-  display: block;
+
+  &__frame {
+    position: relative;
+    width: 100%;
+    height: 600px;
+    border-radius: 8px;
+    overflow: hidden;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+
+    @media (max-width: $tablet) {
+      height: 500px;
+    }
+
+    @media (max-width: $mobile) {
+      height: 400px;
+    }
+  }
+
+  &__canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  &__overlay {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 1rem;
+    background-color: rgba($white, 0.6);
+    z-index: 1;
+
+    &--error {
+      background-color: rgba($white, 0.9);
+      color: $deepCharcoal;
+    }
+
+    p {
+      max-width: 24rem;
+      margin: 0;
+    }
+  }
+
+  &__caption {
+    margin: 0.75rem 0 0;
+    font-size: 0.85rem;
+    line-height: 1.4;
+    color: $deepCharcoal;
+  }
+
+  &__source {
+    opacity: 0.7;
+  }
 }

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
+import ArcgisRasterMap from './arcgis-raster-map';
 import Button from './button';
 import DownloadData from './download-data';
 import FilterBar from './filter-bar';
@@ -12,6 +13,7 @@ import ScrollableTextBox from './scrollable-text-box';
 import Tabs from './tabs';
 
 export {
+  ArcgisRasterMap,
   Button,
   DownloadData,
   FilterBar,

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -141,7 +141,17 @@ const MAP_TITLES = {
   COMPARISON: 'Observed vs Predicted',
 };
 
+// ArcGIS Online item ids for the Maps section. Content is managed in ArcGIS
+// Online; republishing an item's service surfaces new tiles in the app.
+// Single source of truth — resolved to a tile URL at runtime (see utils/arcgis.js).
+const ARCGIS_MAP_ITEMS = {
+  FRAGMENTATION: '2a9a5a50f9f447c6bfde29e588c01022',
+  TREE_DENSITY: '', // fill when client provides the item id
+  MIN_WINTER_TEMP: '', // animated time series — needs time-enabled handling, not a static raster
+};
+
 export {
+  ARCGIS_MAP_ITEMS,
   CHART_MODES,
   DATA_MODES,
   DATA_TYPE_EXTENSIONS,

--- a/src/screens/maps/fragmentation/component.js
+++ b/src/screens/maps/fragmentation/component.js
@@ -1,8 +1,9 @@
 import React from 'react';
-import './style.scss';
 
-// Placeholder URL - to be updated with actual ArcGIS Online embed URL
-const IFRAME_URL = '';
+import { ArcgisRasterMap } from '../../../components';
+import { ARCGIS_MAP_ITEMS } from '../../../constants';
+
+import './style.scss';
 
 const FragmentationMap = () => {
   return (
@@ -11,13 +12,8 @@ const FragmentationMap = () => {
         <div className="page-header">
           <h1>Fragmentation</h1>
         </div>
-        <div className="iframe-container">
-          <iframe
-            src={IFRAME_URL}
-            title="Fragmentation Map"
-            allowFullScreen
-            className="map-iframe"
-          />
+        <div className="map-embed-container">
+          <ArcgisRasterMap itemId={ARCGIS_MAP_ITEMS.FRAGMENTATION} title="Fragmentation Map" />
         </div>
       </div>
     </div>

--- a/src/screens/maps/fragmentation/style.scss
+++ b/src/screens/maps/fragmentation/style.scss
@@ -26,19 +26,7 @@
 
     .map-embed-container {
       width: 100%;
-      height: 600px;
       margin-top: 2rem;
-      border-radius: 8px;
-      overflow: hidden;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-
-      @media (max-width: $tablet) {
-        height: 500px;
-      }
-
-      @media (max-width: $mobile) {
-        height: 400px;
-      }
     }
   }
 }

--- a/src/screens/maps/fragmentation/style.scss
+++ b/src/screens/maps/fragmentation/style.scss
@@ -24,26 +24,20 @@
       // Uses global styles from main.scss
     }
 
-    .iframe-container {
+    .map-embed-container {
       width: 100%;
+      height: 600px;
       margin-top: 2rem;
       border-radius: 8px;
       overflow: hidden;
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
 
-      .map-iframe {
-        width: 100%;
-        height: 600px;
-        border: none;
-        display: block;
+      @media (max-width: $tablet) {
+        height: 500px;
+      }
 
-        @media (max-width: $tablet) {
-          height: 500px;
-        }
-
-        @media (max-width: $mobile) {
-          height: 400px;
-        }
+      @media (max-width: $mobile) {
+        height: 400px;
       }
     }
   }

--- a/src/utils/arcgis.js
+++ b/src/utils/arcgis.js
@@ -12,10 +12,17 @@ const ARCGIS_PORTAL = 'https://www.arcgis.com';
 /**
  * Resolves an ArcGIS Online item id to a mapbox-gl raster tile template and bounds.
  * @param {string} itemId - ArcGIS Online portal item id (a hosted tile Map Service)
- * @returns {Promise<{ tileUrl: string, bounds: ?[[number, number], [number, number]] }|null>}
+ * @returns {Promise<{
+ *            tileUrl: string,
+ *            bounds: ?[[number, number], [number, number]],
+ *            title: ?string,
+ *            snippet: ?string,
+ *            modified: ?number,
+ *          }|null>}
  *          tileUrl is an XYZ template ready for a mapbox raster source; bounds is the
- *          item extent as [[west, south], [east, north]] (lng/lat) or null if absent.
- *          Returns null when the item cannot be resolved.
+ *          item extent as [[west, south], [east, north]] (lng/lat) or null if absent;
+ *          title/snippet are the item's metadata and modified is its last-updated epoch
+ *          (ms). Returns null when the item cannot be resolved.
  */
 export const resolveArcgisTileLayer = async (itemId) => {
   if (!itemId) return null;
@@ -41,7 +48,13 @@ export const resolveArcgisTileLayer = async (itemId) => {
       ? item.extent
       : null;
 
-    return { tileUrl, bounds };
+    return {
+      tileUrl,
+      bounds,
+      title: item.title || null,
+      snippet: item.snippet || null,
+      modified: typeof item.modified === 'number' ? item.modified : null,
+    };
   } catch (error) {
     logWarning('Error resolving ArcGIS tile layer', error, { function: 'resolveArcgisTileLayer', itemId });
     return null;

--- a/src/utils/arcgis.js
+++ b/src/utils/arcgis.js
@@ -1,0 +1,51 @@
+/**
+ * Helpers for consuming ArcGIS Online hosted tile layers.
+ *
+ * Content is managed by the client in ArcGIS Online. We reference a layer by its
+ * portal item id and resolve the live tile service at runtime, so republishing the
+ * service in ArcGIS surfaces new tiles in the app without a code change.
+ */
+import { logWarning } from './logger';
+
+const ARCGIS_PORTAL = 'https://www.arcgis.com';
+
+/**
+ * Resolves an ArcGIS Online item id to a mapbox-gl raster tile template and bounds.
+ * @param {string} itemId - ArcGIS Online portal item id (a hosted tile Map Service)
+ * @returns {Promise<{ tileUrl: string, bounds: ?[[number, number], [number, number]] }|null>}
+ *          tileUrl is an XYZ template ready for a mapbox raster source; bounds is the
+ *          item extent as [[west, south], [east, north]] (lng/lat) or null if absent.
+ *          Returns null when the item cannot be resolved.
+ */
+export const resolveArcgisTileLayer = async (itemId) => {
+  if (!itemId) return null;
+
+  try {
+    const response = await fetch(`${ARCGIS_PORTAL}/sharing/rest/content/items/${itemId}?f=json`);
+    if (!response.ok) {
+      logWarning('ArcGIS item request failed', { status: response.status }, { function: 'resolveArcgisTileLayer', itemId });
+      return null;
+    }
+
+    const item = await response.json();
+    if (item.error || !item.url) {
+      logWarning('ArcGIS item has no service url', item.error || null, { function: 'resolveArcgisTileLayer', itemId });
+      return null;
+    }
+
+    // item.url points at the MapServer/ImageServer endpoint of the hosted tile service.
+    const tileUrl = `${item.url.replace(/\/$/, '')}/tile/{z}/{y}/{x}`;
+
+    // extent is [[xmin, ymin], [xmax, ymax]] in lng/lat -> mapbox bounds [[w, s], [e, n]].
+    const bounds = Array.isArray(item.extent) && item.extent.length === 2
+      ? item.extent
+      : null;
+
+    return { tileUrl, bounds };
+  } catch (error) {
+    logWarning('Error resolving ArcGIS tile layer', error, { function: 'resolveArcgisTileLayer', itemId });
+    return null;
+  }
+};
+
+export default resolveArcgisTileLayer;

--- a/src/utils/map.js
+++ b/src/utils/map.js
@@ -422,6 +422,7 @@ export {
   downloadMap,
   generateMap,
   isInvalidNumber,
+  MAP_STYLE_URL,
   mapboxHoverStyle,
   zoomToSelectedState,
 };


### PR DESCRIPTION
## Description

Wires the **Fragmentation** map page (from #714) to the client-managed ArcGIS Online layer, replacing the empty iframe placeholder. Built as a **mapbox-gl raster layer** (app already uses mapbox-gl) — no new dependency, no second map engine, no iframe chrome.

The layer is referenced by its ArcGIS **item id** and resolved to its live tile service at runtime, so republishing in ArcGIS updates the app **without a code change**.

Base is `maps-page` (PR #714), not `dev`, since the Maps section scaffolding isn't merged yet.

## Changes

- **`ArcgisRasterMap`** component (`src/components/arcgis-raster-map/`) — reusable, ref-based container, cleanup guarded against WebGL leaks. Keys layer setup off style readiness (`styledata`), not the `load` event, so it works even when the tab is backgrounded.
- **`resolveArcgisTileLayer`** util (`src/utils/arcgis.js`) — item id → tile URL + extent + metadata (title/snippet/modified).
- **`ARCGIS_MAP_ITEMS`** config in `constants` — single source of truth for item ids.
- **Loading** state (inline spinner) and **error** state (friendly message when the item can't be resolved; per-tile 404s outside the extent are ignored).
- **Caption** below the map: source + last-updated date from item metadata (placeholder snippets suppressed).
- Fragmentation page + styles wired to the component.

## Test item

Fragmentation uses ArcGIS item `2a9a5a50f9f447c6bfde29e588c01022` (public hosted tile Map Service `SPBFragExport`, Web Mercator).

## Verified

- Raster renders over the SE US; tiles fetched from `.../SPBFragExport/MapServer/tile/{z}/{y}/{x}` return 200 (404s only outside the data extent — expected).
- Loading → ready transition; caption renders with source + date; error path returns null on a bad/private id.
- `npm run lint` clean.

## Notes / follow-ups

- **Tree Density** and **Minimum Winter Temperature** pages still use the iframe placeholder — pending item ids from the client. Min Winter Temp is an animated time series and will need time-enabled handling (not a static raster).
- Product/UX questions for the client and a proactive-improvements plan are drafted in the workspace `.context/` (not committed).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/dali-lab/codesmith/pine-beetle-frontend/pr/721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787407714&installation_model_id=21824&pr_number=721&repository=dali-lab%2Fpine-beetle-frontend&return_to=https%3A%2F%2Fgithub.com%2Fdali-lab%2Fpine-beetle-frontend%2Fpull%2F721&signature=5140bac4cda41e0388d42b2a60b5a7ed9df2f1b77814f9a8d9037b0f3c1573da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->